### PR TITLE
Make Mash#delete works with Symbol key

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -85,6 +85,10 @@ module Hashie
       regular_reader(ck)
     end
 
+    def delete(key)
+      super(convert_key(key))
+    end
+
     alias_method :regular_dup, :dup
     # Duplicates the current mash as a new mash.
     def dup

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -128,6 +128,20 @@ describe Hashie::Mash do
         duped.details.email.should be_nil
       end
     end
+
+    describe 'delete' do
+      it 'should delete with String key' do
+        subject.delete('details')
+        subject.details.should be_nil
+        subject.should_not be_respond_to :details
+      end
+
+      it 'should delete with Symbol key' do
+        subject.delete(:details)
+        subject.details.should be_nil
+        subject.should_not be_respond_to :details
+      end
+    end
   end
 
   it "should convert hash assignments into Hashie::Mashes" do


### PR DESCRIPTION
Hi mbleigh, I found Mash#delete not works with Symbol key as expected, so created a little patch to fix it, hope it helps.
