### PR TITLE
Allow 'type' to be a key on a Mash

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -61,6 +61,10 @@ module Hashie
       key?("id") ? self["id"] : super
     end
 
+    def type #:nodoc:
+      key?("type") ? self["type"] : super
+    end
+    
     alias_method :regular_reader, :[]
     alias_method :regular_writer, :[]=
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -81,6 +81,15 @@ describe Hashie::Mash do
     @mash.author.website.should == Hashie::Mash.new(:url => "http://www.mbleigh.com/")
   end
 
+  it "should call super if type is not a key" do
+    @mash.type.should == Hashie::Mash
+  end
+  
+  it "should return the value if type is a key" do    
+    @mash.type = "Steve"
+    @mash.type.should == "Steve"
+  end
+  
   context "updating" do
     subject {
       described_class.new :first_name => "Michael", :last_name => "Bleigh",


### PR DESCRIPTION
I needed to use the key "type" on a Mash. Object#type is deprecated.
