### PR TITLE
Modify Hashie::Mash#respond_to? to work properly with delegation library

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -64,7 +64,7 @@ module Hashie
     def type #:nodoc:
       key?("type") ? self["type"] : super
     end
-    
+
     alias_method :regular_reader, :[]
     alias_method :regular_writer, :[]=
 
@@ -145,11 +145,11 @@ module Hashie
 
    # Will return true if the Mash has had a key
    # set in addition to normal respond_to? functionality.
-   def respond_to?(method_name)
+   def respond_to?(method_name, include_private=false)
      return true if key?(method_name)
      super
    end
-   
+
    def method_missing(method_name, *args, &blk)
      return self.[](method_name, &blk) if key?(method_name)
      match = method_name.to_s.match(/(.*?)([?=!]?)$/)


### PR DESCRIPTION
Hello Michael,

I'm working on a new gem that utilizes your Hashie gem (great tool, by the way!). As you can see in the specs for this pull request, I'm trying to wrap a Hashie::Mash instance in a DelegateClass instance (from Ruby's delegate.rb). Please take a look at the pull request when you get a chance. I think it's fairly low-risk.

Thanks!

Ryan

enhance Hashie::Mash#respond_to? so that it supports the optional include_private argument - needed to work properly with Ruby's DelegateClass and friends
