### PR TITLE
Add aliases for Mash#key? to conform with standard Ruby Hash aliases.

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -104,6 +104,9 @@ module Hashie
     def key?(key)
       super(convert_key(key))
     end
+    alias_method :has_key?, :key?
+    alias_method :include?, :key?
+    alias_method :member?, :key?
 
     # Performs a deep_update on a duplicate of the
     # current mash.


### PR DESCRIPTION
Hashes have a number of alternates to .has_key? which are shown at http://www.ruby-doc.org/core/classes/Hash.html#M000767 This commit adds those aliases for Hashie::Mash#key? so that the following doesn't happen:

``` ruby
pry(main)> Hashie::Mash.new 'stringy' => 'foo'
=> {
    "stringy" => "foo"
}
pry(main)> mash = _
=> {
    "stringy" => "foo"
}
pry(main)> mash[:stringy]
=> "foo"
pry(main)> mash[:stringy] = "bar"
=> "bar"
pry(main)> mash.inspect
=> "<#Hashie::Mash stringy=\"bar\">"
pry(main)> mash.keys
=> [
    [0] "stringy"
]
pry(main)> mash.has_key? :stringy
=> false
pry(main)> mash.key? :stringy
=> true
```
