### PR TITLE
#inspect should start with #<

### DIFF
--- a/lib/hashie/hash_extensions.rb
+++ b/lib/hashie/hash_extensions.rb
@@ -38,7 +38,7 @@ module Hashie
     end
 
     def hashie_inspect
-      ret = "<##{self.class.to_s}"
+      ret = "#<#{self.class.to_s}"
       stringify_keys.keys.sort.each do |key|
         ret << " #{key}=#{self[key].inspect}"
       end


### PR DESCRIPTION
That is,

``` ruby
>> Hashie::Mash.new
=> <#Hashie::Mash>
```

should be

``` ruby
>> Hashie::Mash.new
=> #<Hashie::Mash>
```

Unless, of course, it's supposed to start with `<#`. The default behavior is to start it with `#<`, in ruby.

``` ruby
>> Object.new
=> #<Object:0x...>
```
