### PR TITLE
Coercion does not work with MergeInitializer

### DIFF
--- a/lib/hashie/extensions/merge_initializer.rb
+++ b/lib/hashie/extensions/merge_initializer.rb
@@ -17,7 +17,9 @@ module Hashie
     module MergeInitializer
       def initialize(hash = {}, default = nil, &block)
         default ? super(default) : super(&block)
-        update(hash)
+        hash.each do |key, value|
+          self[key] = value
+        end
       end
     end
   end

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -17,7 +17,10 @@ describe Hashie::Extensions::Coercion do
   end
 
   before(:each) do
-    class ExampleCoercableHash < Hash; include Hashie::Extensions::Coercion end
+    class ExampleCoercableHash < Hash
+      include Hashie::Extensions::Coercion
+      include Hashie::Extensions::MergeInitializer
+    end
   end
   subject { ExampleCoercableHash }
   let(:instance){ subject.new }
@@ -38,6 +41,13 @@ describe Hashie::Extensions::Coercion do
       instance[:foo] = "bar"
       instance[:foo].value.should == "String"
       instance[:foo].should_not be_coerced
+    end
+
+    it "should coerce when the merge initializer is used" do
+      subject.coerce_key :foo, Coercable
+      instance = subject.new(:foo => "bar")
+
+      instance[:foo].should be_coerced
     end
   end
 


### PR DESCRIPTION
When using MergeInitializer, the calling of core method Hash#update skips the custom method `Hash#[]=` created in the Coercion extension. This prevents the values from being coerced as expected.
