### PR TITLE
Let coerce_key support an array of keys to coerce.

### DIFF
--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -29,17 +29,21 @@ module Hashie
         # and then by calling Class.new with the value as an argument
         # in either case.
         #
-        # @param [Object] key the key you would like to be coerced.
-        # @param [Class] into the class into which you want the key coerced.
+        # @param [Object] key the key or array of keys you would like to be coerced.
+        # @param [Class] into the class into which you want the key(s) coerced.
         #
         # @example Coerce a "user" subhash into a User object
         #   class Tweet < Hash
         #     include Hashie::Extensions::Coercion
         #     coerce_key :user, User
         #   end
-        def coerce_key(key, into)
-          (@key_coercions ||= {})[key] = into
+        def coerce_key(*attrs)
+          @key_coercions ||= {}
+          into = attrs.pop
+          attrs.each { |key| @key_coercions[key] = into }
         end
+
+        alias :coerce_keys :coerce_key
 
         # Returns a hash of any existing key coercions.
         def key_coercions

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -32,6 +32,15 @@ describe Hashie::Extensions::Coercion do
       instance[:foo].should be_coerced
     end
 
+    it "should support an array of keys" do
+      subject.coerce_keys :foo, :bar, Coercable
+
+      instance[:foo] = "bar"
+      instance[:bar] = "bax"
+      instance[:foo].should be_coerced
+      instance[:bar].should be_coerced
+    end
+
     it 'should just call #new if no coerce method is available' do
       subject.coerce_key :foo, Initializable
 


### PR DESCRIPTION
I'v updated the `coerce_key` method to support passing an array of keys, which I think would be quite useful. Also added an alias to the method, called `coerce_keys`
