### PR TITLE
Make explicit the reference to standard Hash

### DIFF
--- a/lib/hashie/hash.rb
+++ b/lib/hashie/hash.rb
@@ -4,7 +4,7 @@ module Hashie
   # A Hashie Hash is simply a Hash that has convenience
   # functions baked in such as stringify_keys that may
   # not be available in all libraries.
-  class Hash < Hash
+  class Hash < ::Hash
     include Hashie::HashExtensions
 
     # Converts a mash back to a hash (with stringified keys)


### PR DESCRIPTION
In Rubinius it ends up not working properly for a bug supposedly in Rubinius' autoload implementation.

I think it could be merged anyway because it makes things more clear and fixes it for Rubinius too.
