### PR TITLE
Deferred defaults for Dash

### DIFF
--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -110,8 +110,13 @@ module Hashie
     def [](property)
       assert_property_exists! property
       value = super(property.to_s)
-      yield value if block_given?
-      value
+      # If the value is a lambda, proc, or whatever answers to call, eval the thing!
+      if value.is_a? Proc
+        self[property] = value.call # Set the result of the call as a value
+      else
+        yield value if block_given?
+        value
+      end
     end
 
     # Set a value on the Dash in a Hash-like way. Only works

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -26,6 +26,10 @@ class DashDefaultTest < Hashie::Dash
   property :aliases, :default => ["Snake"]
 end
 
+class DeferredTest < Hashie::Dash
+  property :created_at, :default => Proc.new { Time.now }
+end
+
 describe DashTest do
 
   subject { DashTest.new(:first_name => 'Bob', :email => 'bob@example.com') }
@@ -97,6 +101,17 @@ describe DashTest do
       value = nil
       subject.first_name { |v| value = v }
       value.should == "Frodo"
+    end
+  end
+
+  context 'reading from deferred properties' do
+    it 'should evaluate proc after initial read' do
+      DeferredTest.new['created_at'].should be_instance_of(Time)
+    end
+
+    it "should not evalute proc after subsequent reads" do
+      deferred = DeferredTest.new
+      deferred['created_at'].object_id.should == deferred['created_at'].object_id
     end
   end
 


### PR DESCRIPTION
Its desirable to have Procs that populate a default value for a key in Dash. Consider a key that generates a GUID and/or populates created_at may be wanted for an object:

``` ruby
class DeferredTest < Hashie::Dash
  property :created_at, :default => Proc.new{ Time.now }
  property :guid, :default => Proc.new{ rand(10000) } # Crappy GUID, I know...
end
```

This pull request adds support for lazily evaluated defaults to Dash to support this use case.
