### PR TITLE
Will now convert hashie objects nested within an array back to a hash wi...

### DIFF
--- a/lib/hashie/hash.rb
+++ b/lib/hashie/hash.rb
@@ -11,7 +11,14 @@ module Hashie
     def to_hash
       out = {}
       keys.each do |k|
-        out[k] = Hashie::Hash === self[k] ? self[k].to_hash : self[k]
+        if self[k].is_a?(Array)
+          out[k] ||= []
+          self[k].each do |array_object|
+            out[k] << (Hashie::Hash === array_object ? array_object.to_hash : array_object)
+          end
+        else
+          out[k] = Hashie::Hash === self[k] ? self[k].to_hash : self[k]
+        end
       end
       out
     end

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -265,5 +265,13 @@ describe Hashie::Mash do
       initial.test.should == []
       initial.test?.should be_true
     end
+
+    it "should convert Hashie::Mashes within Arrays back to Hashes" do
+      initial_hash = {"a" => [{"b" => 12, "c" =>["d" => 50, "e" => 51]}, 23]}
+      converted = Hashie::Mash.new(initial_hash)
+      converted.to_hash["a"].first.is_a?(Hashie::Mash).should be_false
+      converted.to_hash["a"].first.is_a?(Hash).should be_true
+      converted.to_hash["a"].first["c"].first.is_a?(Hashie::Mash).should be_false
+    end
   end
 end


### PR DESCRIPTION
...thin an array.

I ran into an issue where some middleware was taking the to_hash and trying to encode it.  Because all of the nested Hashie objects weren't being converted back to Hashes, the nested Hashie objects were having .to_s being called on them, rather than the to_hash.  It seems like a better idea that to_hash convert the entire object, and all nested Hashie::Mash objects back to hashes.
