### PR TITLE
initialize translations before other properties in trash

### DIFF
--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -93,9 +93,7 @@ module Hashie
         self[prop] = value
       end
 
-      attributes.each_pair do |att, value|
-        self[att] = value
-      end if attributes
+      initialize_attributes(attributes)
       assert_required_properties_set!
     end
 
@@ -121,6 +119,12 @@ module Hashie
     end
 
     private
+
+      def initialize_attributes(attributes)
+        attributes.each_pair do |att, value|
+          self[att] = value
+        end if attributes
+      end
 
       def assert_property_exists!(property)
         unless self.class.property?(property)

--- a/lib/hashie/trash.rb
+++ b/lib/hashie/trash.rb
@@ -51,5 +51,18 @@ module Hashie
       end
       true
     end
+
+    private
+
+    def initialize_attributes(attributes)
+      return unless attributes
+      attributes_copy=attributes.dup.delete_if do |k,v|
+        if self.class.translations.include?(k.to_sym)
+          self[k]=v
+          true
+        end
+      end
+      super attributes_copy
+    end
   end
 end

--- a/spec/hashie/trash_spec.rb
+++ b/spec/hashie/trash_spec.rb
@@ -63,6 +63,12 @@ describe Hashie::Trash do
       TrashTest.new(:first_name => 'Michael').first_name.should == 'Michael'
     end
 
+    context "with both the translated property and the property" do
+      it 'sets the desired properties' do
+        TrashTest.new(:first_name => 'Michael', :firstName=>'Maeve').first_name.should == 'Michael'
+      end
+    end
+
     it 'sets the translated properties' do
       TrashTest.new(:firstName => 'Michael').first_name.should == 'Michael'
     end


### PR DESCRIPTION
When initializing a trash with both the translated and target keys in the input hash, the value of the target key should be honored.  Currently, it depends on how your hash keys are ordered.
