### PR TITLE
Modifies respond_to? according to method_missing

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -149,8 +149,7 @@ module Hashie
    # Will return true if the Mash has had a key
    # set in addition to normal respond_to? functionality.
    def respond_to?(method_name, include_private=false)
-     return true if key?(method_name)
-     super
+     return super || true
    end
 
    def method_missing(method_name, *args, &blk)

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -157,13 +157,13 @@ describe Hashie::Mash do
       it 'should delete with String key' do
         subject.delete('details')
         subject.details.should be_nil
-        subject.should_not be_respond_to :details
+        subject.key?(:details).should be_false
       end
 
       it 'should delete with Symbol key' do
         subject.delete(:details)
         subject.details.should be_nil
-        subject.should_not be_respond_to :details
+        subject.key?(:details).should be_false
       end
     end
   end
@@ -224,6 +224,10 @@ describe Hashie::Mash do
 
     it 'should respond to a set key' do
       Hashie::Mash.new(:abc => 'def').should be_respond_to(:abc)
+    end
+
+    it 'should respond to a non set key' do
+      Hashie::Mash.new.should be_respond_to(:abc)
     end
   end
 


### PR DESCRIPTION
The method respond_to? in Mash should acts like method_missing.
