### PR TITLE
Small addition (with tests & updated doc) to allow read-only multi-level tests

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -124,6 +124,11 @@ to JSON and XML parsed hashes.
     mash.author!.name = "Michael Bleigh"
     mash.author # => <Hashie::Mash name="Michael Bleigh">
 
+    mash = Mash.new
+    # use under-bang methods for multi-level testing
+    mash.author_.name? # => false
+    mash.inspect # => <Hashie::Mash>
+
 **Note:** The `?` method will return false if a key has been set
 to false or nil. In order to check if a key has been set at all, use the
 `mash.key?('some_key')` method instead.

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -71,6 +71,15 @@ describe Hashie::Mash do
     @mash.name!.should == "Bob"
   end
 
+  it "should return a Hashie::Mash when passed an under bang method to a non-existenct key" do
+    @mash.abc_.is_a?(Hashie::Mash).should be_true
+  end
+
+  it "should return the existing value when passed an under bang method for an existing key" do
+    @mash.name = "Bob"
+    @mash.name_.should == "Bob"
+  end
+
   it "#initializing_reader should return a Hashie::Mash when passed a non-existent key" do
     @mash.initializing_reader(:abc).is_a?(Hashie::Mash).should be_true
   end
@@ -81,6 +90,13 @@ describe Hashie::Mash do
     @mash.author!.website!.url = "http://www.mbleigh.com/"
     @mash.author.website.should == Hashie::Mash.new(:url => "http://www.mbleigh.com/")
   end
+
+  it "should allow for multi-level under bang testing" do
+    @mash.author_.website_.url.should be_nil
+    @mash.author_.website_.url?.should == false
+    @mash.author.should be_nil
+  end
+
 
   # it "should call super if type is not a key" do
   #   @mash.type.should == Hashie::Mash
@@ -203,6 +219,18 @@ describe Hashie::Mash do
     son = SubMash.new
     son.non_existent!.should be_kind_of(SubMash)
   end
+
+  it "should respect the class when passed an under bang method for a non-existent key" do
+    record = Hashie::Mash.new
+    record.non_existent_.should be_kind_of(Hashie::Mash)
+
+    class SubMash < Hashie::Mash
+    end
+
+    son = SubMash.new
+    son.non_existent_.should be_kind_of(SubMash)
+  end
+
 
   it "should respect the class when converting the value" do
     record = Hashie::Mash.new


### PR DESCRIPTION
Under-bang is similar to Mash's bang (!) operation, except that it doesn't create new keys.  Instead, it just returns an unassociated new Mash instance when it encounters a missing key.

Example:

```
mash = Hashie::Mash.new
mash.author_.name? # => false
mash.author_.website_.url # => nil
mash.author_.age = 100 # => 100   (assigned to temp on stack)
mash.inspect # => <Hashie::Mash>
```
