### PR TITLE
respect other Hashie::Hash subclasses when assigning a value

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -203,6 +203,8 @@ module Hashie
       case val
         when self.class
           val.dup
+        when Hash
+          duping ? val.dup : val
         when ::Hash
           val = val.dup if duping
           self.class.new(val)

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -236,13 +236,17 @@ describe Hashie::Mash do
     record = Hashie::Mash.new
     record.details = Hashie::Mash.new({:email => "randy@asf.com"})
     record.details.should be_kind_of(Hashie::Mash)
+  end
+
+  it "should respect another subclass when converting the value" do
+    record = Hashie::Mash.new
 
     class SubMash < Hashie::Mash
     end
 
-    son = SubMash.new
-    son.details = Hashie::Mash.new({:email => "randyjr@asf.com"})
-    son.details.should be_kind_of(SubMash)
+    son = SubMash.new({:email => "foo@bar.com"})
+    record.details = son
+    record.details.should be_kind_of(SubMash)
   end
 
   describe '#respond_to?' do


### PR DESCRIPTION
When assigning a raw ruby Hash, the hash should be converted
to the current subclass. But when assigning an existing
subclass, we should keep the existing subclass's type.

Example:

``` ruby
h = {:foo => 'bar'}
m = Hashie::Mash.new
m.value = h
m.value.class  # Hashie::Mash

class SubMash < Hashie::Mash
end

h = SubMash.new(:foo => 'bar')
m = Hashie::Mash.new
m.value = h
m.value.class  # Hashie::SubMash  <- should not be converted to a Mash
```
