### PR TITLE
Make explicit the reference to standard Hash

### DIFF
--- a/lib/hashie/hash.rb
+++ b/lib/hashie/hash.rb
@@ -4,7 +4,7 @@ module Hashie
   # A Hashie Hash is simply a Hash that has convenience
   # functions baked in such as stringify_keys that may
   # not be available in all libraries.
-  class Hash < Hash
+  class Hash < ::Hash
     include Hashie::HashExtensions
 
     # Converts a mash back to a hash.


### PR DESCRIPTION
the old version defines a new class called Hash inside the hashie module in the following manner: "class Hash < Hash". This is fine, and the second Hash there refers to ruby's Hash, but if for some reason the class is being reloaded it produces a superclass mismatch error. Defining the class like this: "class Hash < ::Hash" disambiguates Hash and allows this code to be reloaded multiple times.

Thanks to @meh who made a similar commit to master - but it's needed in the stable branch (and a new release is needed as well)
