### PR TITLE
Alias equivalents of the key predicate (#key?)

### DIFF
--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -31,6 +31,10 @@ module Hashie
             alias_method "regular_#{m}", m
             alias_method m, "indifferent_#{m}"
           end
+
+          %w(include? member? has_key?).each do |key_alias|
+            alias_method key_alias, :indifferent_key?
+          end
         end
       end
 

--- a/spec/hashie/extensions/indifferent_access_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_spec.rb
@@ -38,10 +38,18 @@ describe Hashie::Extensions::IndifferentAccess do
   end
 
   describe '#key?' do
+    let(:h) { subject.new(:foo => 'bar') }
+
     it 'should find it indifferently' do
-      h = subject.new(:foo => 'bar')
       h.should be_key(:foo)
       h.should be_key('foo')
+    end
+
+    %w(include? member? has_key?).each do |key_alias|
+      it "should be aliased as #{key_alias}" do
+        h.send(key_alias.to_sym, :foo).should be(true)
+        h.send(key_alias.to_sym, 'foo').should be(true)
+      end
     end
   end
 


### PR DESCRIPTION
Pretty straightforward.

We noticed that `IndifferentAccess` was failing when we used `has_key?` rather than `key?`.  I aliased [the others](http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-key-3F) for good measure.

I tried to match the style I observed in the code.  If you have any questions, please let me know.
