### PR TITLE
Don't call super when Mash doesn't have id or type

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -77,6 +77,10 @@ module Hashie
       self["type"]
     end
 
+    def object_id #:nodoc:
+      self["object_id"]
+    end
+
     alias_method :regular_reader, :[]
     alias_method :regular_writer, :[]=
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -97,6 +97,16 @@ describe Hashie::Mash do
     @mash.author.should be_nil
   end
 
+  it "should not call super if object_id is not a key" do
+    @mash.object_id.should == nil
+  end
+
+  it "should return the value if object_id is a key" do
+    @mash.object_id = "Steve"
+    @mash.object_id.should == "Steve"
+  end
+
+
   it "should not call super if id is not a key" do
     @mash.id.should == nil
   end
@@ -291,11 +301,11 @@ describe Hashie::Mash do
       initial = Hashie::Mash.new(:name => 'randy', :address => {:state => 'TX'})
       copy = Hashie::Mash.new(initial)
       initial.name.should == copy.name
-      initial.object_id.should_not == copy.object_id
+      initial.__id__.should_not == copy.__id__
       copy.address.state.should == 'TX'
       copy.address.state = 'MI'
       initial.address.state.should == 'TX'
-      copy.address.object_id.should_not == initial.address.object_id
+      copy.address.__id__.should_not == initial.address.__id__
     end
 
     it "should accept a default block" do


### PR DESCRIPTION
Ruby 1.8 has an Object#id method that is called when the
Mash doesn't have an id key. This causes unexpected failures since
there is no id key-value, but Mash is still returning a value. If the
object_id is needed just use #object_id or #__id__

(Same with type -> use class)
