### PR TITLE
add license information to the gemspec

### DIFF
--- a/hashie.gemspec
+++ b/hashie.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.name          = "hashie"
   gem.require_paths = ['lib']
   gem.version       = Hashie::VERSION
+  gem.license       = "MIT"
 
   gem.add_development_dependency 'rake', '~> 0.9.2'
   gem.add_development_dependency 'rspec', '~> 2.5'


### PR DESCRIPTION
This way you can get this info from rubygems.org API
