### PR TITLE
Hashie::Hash#to_hash updated to recurse through ::Hash as well

### DIFF
--- a/lib/hashie/hash.rb
+++ b/lib/hashie/hash.rb
@@ -8,19 +8,23 @@ module Hashie
     include HashExtensions
 
     # Converts a mash back to a hash (with stringified keys)
-    def to_hash
+    def self.to_hash(hash)
       out = {}
-      keys.each do |k|
-        if self[k].is_a?(Array)
+      hash.keys.each do |k|
+        if hash[k].is_a?(Array)
           out[k] ||= []
-          self[k].each do |array_object|
-            out[k] << (::Hash === array_object ? array_object.to_hash : array_object)
+          hash[k].each do |array_object|
+            out[k] << (::Hash === array_object ? to_hash(array_object) : array_object)
           end
         else
-          out[k] = ::Hash === self[k] ? self[k].to_hash : self[k]
+          out[k] = ::Hash === hash[k] ? to_hash(hash[k]) : hash[k]
         end
       end
       out
+    end
+
+    def to_hash
+      self.class.to_hash(self)
     end
 
     # The C geneartor for the json gem doesn't like mashies

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -327,6 +327,14 @@ describe Hashie::Mash do
       converted.to_hash["a"].first.is_a?(Hash).should be_true
       converted.to_hash["a"].first["c"].first.is_a?(Hashie::Mash).should be_false
     end
+    
+    it "should convert Hashie::Mashes within Hashes back to Hashes" do
+      nested_mash = Hashie::Mash.new
+      initial_hash = {"a" => [{"b" => 22, "c" =>[{"d" => 60, "e" => 61, "nested" => nested_mash}]}, 33]}
+      converted = Hashie::Mash.new(initial_hash)
+      converted.to_hash["a"].first.is_a?(Hash).should be_true
+      converted.to_hash["a"].first["c"].first["nested"].is_a?(Hashie::Mash).should be_false
+    end
   end
   
   describe "#fetch" do


### PR DESCRIPTION
The problem is, when a Hashie::Hash is nested deep within a regular Hash, it won't be converted. This will recursively process a regular Hash as well.
