### PR TITLE
Remove override of object_id #77

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -77,10 +77,6 @@ module Hashie
       self["type"]
     end
 
-    def object_id #:nodoc:
-      self["object_id"]
-    end
-
     alias_method :regular_reader, :[]
     alias_method :regular_writer, :[]=
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -97,15 +97,6 @@ describe Hashie::Mash do
     @mash.author.should be_nil
   end
 
-  it "should not call super if object_id is not a key" do
-    @mash.object_id.should == nil
-  end
-
-  it "should return the value if object_id is a key" do
-    @mash.object_id = "Steve"
-    @mash.object_id.should == "Steve"
-  end
-
   it "should not call super if id is not a key" do
     @mash.id.should == nil
   end


### PR DESCRIPTION
Avoids this warning on 1.9.3:

```
/Users/mat/.rvm/gems/ruby-1.9.3-p194@.../gems/hashie-2.0.0/lib/hashie/mash.rb:80: warning: redefining `object_id' may cause serious problems
```
