### PR TITLE
Fix Hashie::Mash#respond_to? with a suffixed key

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -184,7 +184,7 @@ module Hashie
     # Will return true if the Mash has had a key
     # set in addition to normal respond_to? functionality.
     def respond_to?(method_name, include_private=false)
-      return true if key?(method_name) || key?(method_name.to_s.sub(/[=?!_]\Z/, ''))
+      return true if key?(method_name) || method_name.to_s.slice(/[=?!_]\Z/)
       super
     end
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -298,10 +298,20 @@ describe Hashie::Mash do
       Hashie::Mash.new(:abc => 'def').should be_respond_to(:abc)
     end
     
-    it 'should respond to a suffixed key' do
+    it 'should respond to a set key with a suffix' do
       %w(= ? ! _).each do |suffix|
         Hashie::Mash.new(:abc => 'def').should be_respond_to(:"abc#{suffix}")
       end
+    end
+    
+    it 'should respond to an unknown key with a suffix' do
+      %w(= ? ! _).each do |suffix|
+        Hashie::Mash.new(:abc => 'def').should be_respond_to(:"xyz#{suffix}")
+      end
+    end
+    
+    it "should not respond to an unknown key without a suffix" do
+      Hashie::Mash.new(:abc => 'def').should_not be_respond_to(:xyz)
     end
   end
 


### PR DESCRIPTION
This simple change just modifies the `Hashie::Mash#respond_to?` method so that it complies with the `#method_missing` behaviour.

Before the fix:

``` ruby
Hashie::Mash.new(abc: true).respond_to?(:abc?) # => false
Hashie::Mash.new(abc: true).respond_to?(:abc=) # => false
```

After the fix:

``` ruby
Hashie::Mash.new(abc: true).respond_to?(:abc?) # => true
```
