### PR TITLE
IndifferentAccess, make #store respect indifference

### DIFF
--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -27,6 +27,7 @@ module Hashie
         base.class_eval do
           alias_method :regular_writer, :[]=
           alias_method :[]=, :indifferent_writer
+          alias_method :store, :indifferent_writer
           %w(default update replace fetch delete key? values_at).each do |m|
             alias_method "regular_#{m}", m
             alias_method m, "indifferent_#{m}"

--- a/spec/hashie/extensions/indifferent_access_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_spec.rb
@@ -13,6 +13,16 @@ describe Hashie::Extensions::IndifferentAccess do
     h['abc'].should == 123
   end
 
+
+  describe '#store' do
+    it 'should indifferently save values' do
+      h = subject.new
+      h.store(:abc, 123)
+      h[:abc].should == 123
+      h['abc'].should == 123
+    end
+  end
+
   describe '#values_at' do
     it 'should indifferently find values' do
       h = subject.new(:foo => 'bar', 'baz' => 'qux')


### PR DESCRIPTION
Hash provides #store as essentially a synonym for #[]= -- but for some reason, in MRI at least, they have different implementations, neither is implemented in terms of the other. 

You forgot to fix #store for indifferent access. Fixed here with a simple alias_method, which is the same [solution ActiveSupport::HashWithIndifferentAccess uses](https://github.com/rails/rails/blob/72f7f94cec42a841a17ab112af27579fcb4d9920/activesupport/lib/active_support/hash_with_indifferent_access.rb#L97). 
