### PR TITLE
Adding support for dash properties that end in bang

### DIFF
--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -39,15 +39,9 @@ module Hashie
       end
 
       unless instance_methods.map { |m| m.to_s }.include?("#{property_name}=")
-        class_eval <<-ACCESSORS
-          def #{property_name}(&block)
-            self.[](#{property_name.to_s.inspect}, &block)
-          end
-
-          def #{property_name}=(value)
-            self.[]=(#{property_name.to_s.inspect}, value)
-          end
-        ACCESSORS
+        define_method(property_name) { |&block| self.[](property_name.to_s, &block) }
+        property_assignment = property_name.to_s.concat("=").to_sym
+        define_method(property_assignment) { |value| self.[]=(property_name.to_s, value) }
       end
 
       if defined? @subclasses

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -18,6 +18,10 @@ class DashNoRequiredTest < Hashie::Dash
   property :count, :default => 0
 end
 
+class PropertyBangTest < Hashie::Dash
+  property :important!
+end
+
 class Subclassed < DashTest
   property :last_name, :required => true
 end
@@ -168,6 +172,10 @@ describe DashTest do
 
     it 'lists declared defaults' do
       described_class.defaults.should == { :count => 0 }
+    end
+
+    it 'allows properties that end in bang' do
+      PropertyBangTest.property?(:important!).should be_true
     end
   end
 


### PR DESCRIPTION
I'm not certain why to_s.inspect was previously used on the property name. 

The tests pass locally (ruby 1.9.3-p194) without #to_s on property_name, but it looks like there is a preference to have the keys of the internal hash as strings instead of symbols.
