### PR TITLE
Fixes Issue #106: deep_merge recursively slow

### DIFF
--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -21,7 +21,7 @@ module Hashie
           super(key, value)
         end
 
-        def custom_writer(key, value)
+        def custom_writer(key, value, convert=true)
           self[key] = value
         end
 

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -91,8 +91,8 @@ module Hashie
     # Sets an attribute in the Mash. Key will be converted to
     # a string before it is set, and Hashes will be converted
     # into Mashes for nesting purposes.
-    def custom_writer(key,value) #:nodoc:
-      regular_writer(convert_key(key), convert_value(value))
+    def custom_writer(key,value,convert=true) #:nodoc:
+      regular_writer(convert_key(key), convert ? convert_value(value) : value)
     end
 
     alias_method :[], :custom_reader
@@ -154,8 +154,8 @@ module Hashie
           custom_reader(key).deep_update(v, &blk)
         else
           value = convert_value(v, true)
-          value = blk.call(key, self[k], value) if blk
-          custom_writer(key, value)
+          value = convert_value(blk.call(key, self[k], value), true) if blk
+          custom_writer(key, value, false)
         end
       end
       self


### PR DESCRIPTION
The call to custom_writer within deep_merge was exponentially converting the values (unnecessarily, since they were just converted within deep_merge).  Added an optional param to custom_writer to suppress the conversion.  Unfortunately, had to also add the param to coercion's customer_writer method as well (which is just ignored) to not break the inheritance.

All tests pass.
