### PR TITLE
Handle keys with special characters [#117]

### DIFF
--- a/lib/hashie/trash.rb
+++ b/lib/hashie/trash.rb
@@ -32,11 +32,11 @@ module Hashie
             end
           end
         else
-          class_eval <<-RUBY
-            def #{options[:from]}=(val)
-              self[:#{property_name}] = val
+          class_eval do
+            define_method "#{options[:from]}=" do |val|
+              self[property_name.to_sym] = val
             end
-          RUBY
+          end
         end
       elsif options[:transform_with].respond_to? :call
         transforms[property_name.to_sym] = options[:transform_with]

--- a/spec/hashie/trash_spec.rb
+++ b/spec/hashie/trash_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Hashie::Trash do
   class TrashTest < Hashie::Trash
     property :first_name, :from => :firstName
+    property :last_name, :from => 'person@lastName'
   end
 
   let(:trash) { TrashTest.new }
@@ -71,6 +72,10 @@ describe Hashie::Trash do
 
     it 'sets the desired properties' do
       TrashTest.new(:first_name => 'Michael').first_name.should == 'Michael'
+    end
+
+    it 'sets properties with special characters' do
+      TrashTest.new('person@lastName' => 'Scott').last_name.should == 'Scott'
     end
 
     context "with both the translated property and the property" do


### PR DESCRIPTION
This fixes issue #117 mentioned by @alhafoudh by using `define_method` instead of an eval.
