### PR TITLE
Remove dynamic include calls in deep_merge

### DIFF
--- a/lib/hashie/extensions/deep_merge.rb
+++ b/lib/hashie/extensions/deep_merge.rb
@@ -3,18 +3,27 @@ module Hashie
     module DeepMerge
       # Returns a new hash with +self+ and +other_hash+ merged recursively.
       def deep_merge(other_hash)
-        (class << (h = dup); self; end).send :include, Hashie::Extensions::DeepMerge
-        h.deep_merge!(other_hash)
+        self.dup.deep_merge!(other_hash)
       end
 
       # Returns a new hash with +self+ and +other_hash+ merged recursively.
       # Modifies the receiver in place.
       def deep_merge!(other_hash)
-        other_hash.each do |k,v|
-          (class << (tv = self[k]); self; end).send :include, Hashie::Extensions::DeepMerge
-          self[k] = tv.is_a?(::Hash) && v.is_a?(::Hash) ? tv.deep_merge(v) : v
-        end
+        _recursive_merge(self, other_hash)
         self
+      end
+
+      private
+
+      def _recursive_merge(hash, other_hash)
+        if other_hash.is_a?(::Hash) && hash.is_a?(::Hash)
+          other_hash.each do |k, v|
+            hash[k] = hash.has_key?(k) ? _recursive_merge(hash[k], v) : v
+          end
+          hash
+        else
+          other_hash
+        end
       end
     end
   end

--- a/spec/hashie/extensions/deep_merge_spec.rb
+++ b/spec/hashie/extensions/deep_merge_spec.rb
@@ -5,16 +5,17 @@ describe Hashie::Extensions::DeepMerge do
 
   subject{ DeepMergeHash }
 
-  let(:h1) { subject.new.merge(:a => "a", :b => "b", :c => { :c1 => "c1", :c2 => "c2", :c3 => { :d1 => "d1" } }) }
-  let(:h2) { { :a => 1, :c => { :c1 => 2, :c3 => { :d2 => "d2" } } } }
-  let(:expected_hash) { { :a => 1, :b => "b", :c => { :c1 => 2, :c2 => "c2", :c3 => { :d1 => "d1", :d2 => "d2" } } } }
+  let(:h1) { subject.new.merge(:a => "a", :a1 => 42, :b => "b", :c => { :c1 => "c1", :c2 => {:a => "b"}, :c3 => { :d1 => "d1" } }) }
+  let(:h2) { { :a => 1, :a1 => 1, :c => { :c1 => 2, :c2 => "c2", :c3 => { :d2 => "d2" } } } }
+  let(:expected_hash) { { :a => 1, :a1 => 1, :b => "b", :c => { :c1 => 2, :c2 => "c2", :c3 => { :d1 => "d1", :d2 => "d2" } } } }
 
-  it 'should deep merge two hashes' do
+  it 'deep merges two hashes' do
     h1.deep_merge(h2).should == expected_hash
   end
 
-  it 'should deep merge two hashes with bang method' do
+  it 'deep merges another hash in place via bang method' do
     h1.deep_merge!(h2)
     h1.should == expected_hash
   end
+
 end


### PR DESCRIPTION
The current implementation is not very desirable, as it a) resets the method cache and b) leaks `Hashie`'s flavour of `deep_merge` onto every class passed into it.

This should resolve #99 
