### PR TITLE
Fix broken Hashie::Hash#to_hash

### DIFF
--- a/lib/hashie/hash.rb
+++ b/lib/hashie/hash.rb
@@ -7,19 +7,19 @@ module Hashie
   class Hash < ::Hash
     include HashExtensions
 
-    # Converts a mash back to a hash (with stringified keys)
+    # Converts a mash back to a hash (with stringified or symbolized keys)
     def to_hash(options={})
       out = {}
       keys.each do |k|
+        assignment_key = k.to_s
+        assignment_key = assignment_key.to_sym if options[:symbolize_keys]
         if self[k].is_a?(Array)
-          k = options[:symbolize_keys] ? k.to_sym : k.to_s
-          out[k] ||= []
+          out[assignment_key] ||= []
           self[k].each do |array_object|
-            out[k] << (Hash === array_object ? array_object.to_hash : array_object)
+            out[assignment_key] << (Hash === array_object ? array_object.to_hash : array_object)
           end
         else
-          k = options[:symbolize_keys] ? k.to_sym : k.to_s
-          out[k] = Hash === self[k] ? self[k].to_hash : self[k]
+          out[assignment_key] = Hash === self[k] ? self[k].to_hash : self[k]
         end
       end
       out

--- a/spec/hashie/hash_spec.rb
+++ b/spec/hashie/hash_spec.rb
@@ -19,4 +19,16 @@ describe Hash do
     hash.should == Hashie::Hash[:a => "hey", 123 => "bob"]
     stringified_hash.should == Hashie::Hash["a" => "hey", "123" => "bob"]
   end
+  
+  it "#to_hash should return a hash with stringified keys" do
+    hash = Hashie::Hash["a" => "hey", 123 => "bob", "array" => [1, 2, 3]]
+    stringified_hash = hash.to_hash
+    stringified_hash.should == {"a" => "hey", "123" => "bob", "array" => [1, 2, 3]}
+  end
+  
+  it "#to_hash with symbolize_keys set to true should return a hash with symbolized keys" do
+    hash = Hashie::Hash["a" => "hey", 123 => "bob", "array" => [1, 2, 3]]
+    symbolized_hash = hash.to_hash(:symbolize_keys => true)
+    symbolized_hash.should == {:a => "hey", :"123" => "bob", :array => [1, 2, 3]}
+  end
 end


### PR DESCRIPTION
Per [my comment on the original pull request for this feature](https://github.com/intridea/hashie/pull/85#issuecomment-34896211):

> I'm running into an issue with this code.  I'm trying to take a basic hash with string keys and convert it to a basic hash with symbol keys.  Take the following example.
> 
> ```
> hash = {"id": 1, "name": "Bob"}
> hash = Hashie::Hash[hash].to_hash(symbolize_keys: true)
> ```
> 
> This throws an exception in Hashie's to_hash method using the code provided here.  The reason is that on line 15 the value of `k` is being changed from `"id"` or `"name"` to `:id` or `:name` respectively.  Then on line 17, the call to `self[k]` returns `nil` since `hash[:id]` is not defined (only `hash["id"]` is defined), which then errors when trying to evaluate `nil.each`.
> 
> I think a proper fix would be to assign the key to a NEW variable instead.  e.g.:
> 
> ```
> assignment_key = options[:symbolize_keys] ? k.to_sym : k.to_s
> out[assignment_key] ||= []
> self[k].each do |array_object|
>   out[assignment_key] << (Hash === array_object ? array_object.to_hash : array_object)
> end
> ```

Additionally, this fixes a similar issue even when `:symbolize_keys` is false (or not provided) to the `#to_hash` function.  If a key is not already a string, then a similar error will be raised.  There was not a test to cover this, so I added one.
