### PR TITLE
Fixed inconsistency between Mash#respond_to? and #method_missing. Added Hashie::Extensions::Mash::ActiveModel for compatibility with Rails 4 Strong Parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
-* Your contribution here.
+* [#146](https://github.com/intridea/hashie/issues/146): Mash#respond_to? inconsistent with #method_missing and does not respond to #permitted? - [@dblock](https://github.com/dblock).
+* [#89](https://github.com/intridea/hashie/issues/89): Added Hashie::Extensions::Mash::ActiveModel for compatibility with Rails 4.x Strong Parameters - [@dblock](https://github.com/dblock).
 
 ## 2.1.1 (4/12/2014)
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,16 @@ p[:awesome]    # => NoMethodError
 p[:occupation] # => 'Rubyist'
 ```
 
+### Mash and Rails 4 Strong Parameters
+
+Add the following initializer in config/initializers/mash.rb when using Mash with [Rails 4 Strong Parameters](http://edgeguides.rubyonrails.org/action_controller_overview.html#strong-parameters). This prevents Mash from responding to `:permitted?` and therefore triggering an ActiveModel `ForbiddenAttributesProtection` exception.
+
+```ruby
+class Mash
+  include Hashie::Extensions::Mash::ActiveModel
+end
+```
+
 ## Trash
 
 A Trash is a Dash that allows you to translate keys on initialization.

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -22,5 +22,9 @@ module Hashie
     autoload :StringifyKeys,     'hashie/extensions/key_conversion'
     autoload :SymbolizeKeys,     'hashie/extensions/key_conversion'
     autoload :DeepFetch,         'hashie/extensions/deep_fetch'
+
+    module Mash
+      autoload :ActiveModel,     'hashie/extensions/mash/active_model'
+    end
   end
 end

--- a/lib/hashie/extensions/mash/active_model.rb
+++ b/lib/hashie/extensions/mash/active_model.rb
@@ -1,0 +1,18 @@
+module Hashie
+  module Extensions
+    module Mash
+      # Extends Mash to behave in a way compatible with ActiveModel.
+      module ActiveModel
+        def respond_to?(name, include_private = false)
+          return false if name == :permitted?
+          super
+        end
+
+        def method_missing(name, *args)
+          fail ArgumentError if name == :permitted?
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -328,9 +328,9 @@ describe Hashie::Mash do
       end
     end
 
-    it 'does not respond to an unknown key with a suffix' do
+    it 'responds to an unknown key with a suffix' do
       %w(= ? ! _).each do |suffix|
-        expect(Hashie::Mash.new(abc: 'def')).not_to be_respond_to(:"xyz#{suffix}")
+        expect(Hashie::Mash.new(abc: 'def')).to be_respond_to(:"xyz#{suffix}")
       end
     end
 
@@ -339,7 +339,12 @@ describe Hashie::Mash do
     end
 
     it 'does not respond to permitted?' do
-      expect(Hashie::Mash.new).not_to be_respond_to(:permitted?)
+      expect(Hashie::Mash.new).to be_respond_to(:permitted?)
+      klass = Class.new(Hashie::Mash) do
+        include Hashie::Extensions::Mash::ActiveModel
+      end
+      expect(klass.new).not_to be_respond_to(:permitted?)
+      expect { klass.new.permitted? }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
I would appreciate comments on the README and the implementation. Maybe there's a way to do this automatically via Railtie or something like that (I don't know how)?

``` ruby
class Mash
  include Hashie::Extensions::Mash::ActiveModel
end
```

Closes #146 and #89.
