### PR TITLE
Spec for issue #149.

### DIFF
--- a/lib/hashie/extensions/ignore_undeclared.rb
+++ b/lib/hashie/extensions/ignore_undeclared.rb
@@ -5,7 +5,7 @@ module Hashie
     # raising an error. This is useful when using a Trash to
     # capture a subset of a larger hash.
     #
-    # Note that attempting to retrieve an undeclared property
+    # Note that attempting to retrieve or set an undeclared property
     # will still raise a NoMethodError, even if a value for
     # that property was provided at initialization.
     #

--- a/spec/hashie/extensions/ignore_undeclared_spec.rb
+++ b/spec/hashie/extensions/ignore_undeclared_spec.rb
@@ -1,23 +1,46 @@
 require 'spec_helper'
 
 describe Hashie::Extensions::IgnoreUndeclared do
-  class ForgivingTrash < Hashie::Trash
-    include Hashie::Extensions::IgnoreUndeclared
-    property :city
-    property :state, from: :provence
+  context 'included in Trash' do
+    class ForgivingTrash < Hashie::Trash
+      include Hashie::Extensions::IgnoreUndeclared
+      property :city
+      property :state, from: :provence
+    end
+
+    subject { ForgivingTrash }
+
+    it 'silently ignores undeclared properties on initialization' do
+      expect { subject.new(city: 'Toronto', provence: 'ON', country: 'Canada') }.to_not raise_error
+    end
+
+    it 'works with translated properties (with symbol keys)' do
+      expect(subject.new(provence: 'Ontario').state).to eq('Ontario')
+    end
+
+    it 'works with translated properties (with string keys)' do
+      expect(subject.new(provence: 'Ontario').state).to eq('Ontario')
+    end
   end
 
-  subject { ForgivingTrash }
+  context 'combined with DeepMerge' do
+    class ForgivingTrashWithMerge < Hashie::Trash
+      include Hashie::Extensions::DeepMerge
+      include Hashie::Extensions::IgnoreUndeclared
+      property :some_key
+    end
 
-  it 'silently ignores undeclared properties on initialization' do
-    expect { subject.new(city: 'Toronto', provence: 'ON', country: 'Canada') }.to_not raise_error
-  end
+    it 'requires properties to be declared on assignment' do
+      hash = ForgivingTrashWithMerge.new(some_ignored_key: 17, some_key: 12)
+      expect { hash.deep_merge(some_other_key: 55) }.to raise_error(NoMethodError)
+    end
 
-  it 'works with translated properties (with symbol keys)' do
-    expect(subject.new(provence: 'Ontario').state).to eq('Ontario')
-  end
-
-  it 'works with translated properties (with string keys)' do
-    expect(subject.new(provence: 'Ontario').state).to eq('Ontario')
+    it 'deep merges' do
+      class ForgivingTrashWithMergeAndProperty < ForgivingTrashWithMerge
+        property :some_other_key
+      end
+      hash = ForgivingTrashWithMergeAndProperty.new(some_ignored_key: 17, some_key: 12)
+      expect(hash.deep_merge(some_other_key: 55)).to eq("some_key" => 12, "some_other_key" => 55)
+    end
   end
 end


### PR DESCRIPTION
With IgnoreUndeclared the behavior of assigning an undeclared property explicitly is still to raise a `NoMethodError`. That extension is only ignoring properties on initialization by design.
