### PR TITLE
Fix Mash#values at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [#179](https://github.com/intridea/hashie/pull/179) Mash#values_at will convert each key before doing the lookup - [@nahiluhmot](https://github.com/nahiluhmot).
 * Your contribution here.
 
 ## 3.1 (6/25/2014)

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -128,6 +128,10 @@ module Hashie
       super(convert_key(key))
     end
 
+    def values_at(*keys)
+      super(*keys.map { |key| convert_key(key) })
+    end
+
     alias_method :regular_dup, :dup
     # Duplicates the current mash as a new mash.
     def dup

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -476,4 +476,27 @@ describe Hashie::Mash do
       expect(hash).to eq Hashie::Hash['a' => 'hey', '123' => { '345' => 'hey' }]
     end
   end
+
+  describe '#values_at' do
+    let(:hash) { { 'key_one' => 1, :key_two => 2 } }
+    let(:mash) { Hashie::Mash.new(hash) }
+
+    context 'when the original type is given' do
+      it 'returns the values' do
+        expect(mash.values_at('key_one', :key_two)).to eq([1, 2])
+      end
+    end
+
+    context 'when a different, but acceptable type is given' do
+      it 'returns the values' do
+        expect(mash.values_at(:key_one, 'key_two')).to eq([1, 2])
+      end
+    end
+
+    context 'when a key is given that is not in the Mash' do
+      it 'returns nil for that value' do
+        expect(mash.values_at('key_one', :key_three)).to eq([1, nil])
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using `Hashie::Mash#values_at`, the keys are not converted before they are looked up, which provides an inconsistent querying API.

This pull addresses that issue.
