### PR TITLE
Allow Ranges on Rash to match all Numerics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * [#179](https://github.com/intridea/hashie/pull/179) Mash#values_at will convert each key before doing the lookup - [@nahiluhmot](https://github.com/nahiluhmot).
+* [#184](https://github.com/intridea/hashie/pull/184) Allow Ranges on Rash to match all Numerics - [@medcat](https://github.com/medcat)
 * Your contribution here.
 
 ## 3.1 (6/25/2014)

--- a/lib/hashie/rash.rb
+++ b/lib/hashie/rash.rb
@@ -89,10 +89,10 @@ module Hashie
           end
         end
 
-      when Integer
+      when Numeric
         # see if any of the ranges match the integer
         @ranges.each do |range|
-          yield @hash[range] if range.include? query
+          yield @hash[range] if range.cover? query
         end
 
       when Regexp

--- a/spec/hashie/rash_spec.rb
+++ b/spec/hashie/rash_spec.rb
@@ -37,6 +37,12 @@ describe Hashie::Rash do
     expect(subject[1001]).to be_nil
   end
 
+  it 'finds floats from ranges' do
+    expect(subject[10.1]).to eq 'rangey'
+    expect(subject[1.0]).to eq 'rangey'
+    expect(subject[1000.1]).to be_nil
+  end
+
   it 'evaluates proc values' do
     expect(subject['abcdef']).to eq 'bcd'
     expect(subject['ffffff']).to be_nil


### PR DESCRIPTION
Previously, it checked only for Integers; unfortunately, that left Floats out, so passing in a float would cause it to look it up normally.  This also changes the range checking to `cover?` instead of `include?`.  Also adds a line to a test to check for float availability.
