### PR TITLE
Sash: save a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,50 @@ mapper["Get off my lawn!"]      # => "Forget your lawn, old man!"
 
 If this value is too low or too high for your needs, you can tune it by setting: `rash.optimize_every = n`.
 
+## Sash
+
+Sash is a savable hash.  It saves the key/value pairs from the hash into a
+YAML file that can be loaded later.  It manages permissions (optionally), can
+create a backup/save file, automatically save on changes, as well as
+automatically load on startup. It can be configured before use, as well as
+reconfigured during use.
+
+### Configuration
+
+Configuration can be either at initialization or after.  The one drawback is
+you cannot (currently) feed it a new hash to set the initial values.
+
+The five main settings are:
+
+* file:     Filename to save the hash to.
+* backup:   Boolean, whether to produce a backup or not.
+* mode:     FixNum: mode to store it as: 0600, 0755, 0644 and so on.
+* auto_save: Boolean: Automatically save on changes.
+* auto_load: Boolean: Automatically load on init.
+
+The values for these do not get stored in the YAML file.  Only the k/v pairs you
+set do.
+
+### Examples
+
+Configuration:
+
+    s = Bini::Sash.new options => {:file => 'filename', :auto_save => true}
+
+Or after creation:
+
+    s.auto_save = true
+    s.auto_load = false
+    s.backup = true
+
+If backup or mode are set, they will update at the next time you save.
+
+During creation you can also pass in a hash to get merged in via the overrides
+param.
+
+    s = Bini::Sash.new options => {:file => 'filename', :auto_save => true},
+        overrides => {foo => 'bar', one => 'two'}
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -1,10 +1,12 @@
 module Hashie
+<<<<<<< HEAD
   autoload :Clash,              'hashie/clash'
   autoload :Dash,               'hashie/dash'
   autoload :Hash,               'hashie/hash'
   autoload :Mash,               'hashie/mash'
   autoload :Trash,              'hashie/trash'
   autoload :Rash,               'hashie/rash'
+  autoload :Sash,		'hashie/sash'
 
   module Extensions
     autoload :Coercion,          'hashie/extensions/coercion'

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -1,5 +1,4 @@
 module Hashie
-<<<<<<< HEAD
   autoload :Clash,              'hashie/clash'
   autoload :Dash,               'hashie/dash'
   autoload :Hash,               'hashie/hash'

--- a/lib/hashie/sash.rb
+++ b/lib/hashie/sash.rb
@@ -5,7 +5,6 @@ module Hashie
   # This is a savable hash, it can be configured and used to store whatever the# contents of the hash are for loading later.  Will serialize in yaml to keep all
   # the dependencies in ruby stdlib.
   class Sash < Hash
-
     attr_accessor :file
     attr_accessor :backup
     attr_accessor :mode
@@ -18,11 +17,11 @@ module Hashie
       # Throw an exception if we get anything more then the two named hash keys.
       # This is to prevent usage errors (you can't initialize a sash quite like
       # a hash since it takes options or overrides.)
-      p = params.select { |k,v| k != :options && k != :overrides}
-      raise ArgumentError, "Extra values passed in: #{p}." if p.count > 0
+      p = params.select { |k, _| k != :options && k != :overrides }
+      fail ArgumentError, "Extra values passed in: #{p}." if p.count > 0
 
       # set our options to our attributes.
-      params[:options].each { |k,v| instance_variable_set "@" + k.to_s,v} if params[:options]
+      params[:options].each { |k, v| instance_variable_set '@' + k.to_s, v } if params[:options]
 
       # should we load our data?
       load if @auto_load
@@ -30,12 +29,12 @@ module Hashie
       # did we get any overrides?
       self.merge! params[:overrides] if params[:overrides]
 
-      return self
+      self
     end
 
     # The base directory of the save file.
     def basedir
-      return nil if !file
+      return nil unless file
       File.dirname File.absolute_path @file
     end
 
@@ -47,12 +46,12 @@ module Hashie
     # Save the hash to the file, check for backup and set_mode.
     def save
       if any?
-        FileUtils.mkdir_p basedir if !Dir.exist? basedir
+        FileUtils.mkdir_p basedir unless Dir.exist? basedir
         backup if @backup
 
         # I do this the long way because I want an immediate sync.
         f = open(@file, 'w')
-        f.write YAML::dump self
+        f.write YAML.dump self
         f.sync
         f.close
 
@@ -61,7 +60,7 @@ module Hashie
       true
     end
     # Store a value in the Hash.  Can autosave.
-    def []=(key,value)
+    def []=(key, value)
       store key, value
       save! if @auto_save == true
     end
@@ -73,12 +72,12 @@ module Hashie
 
     # Load the save file into self.
     def load
-      self.clear
+      clear
       if @file && File.exist?(@file) && File.stat(@file).size > 0
-        h = YAML::load open(@file, 'r').read
-        h.each { |k,v| self[k] = v}
+        h = YAML.load open(@file, 'r').read
+        h.each { |k, v| self[k] = v }
       end
-      return self
+      self
     end
 
     # Generate a backup file real quick.
@@ -89,11 +88,11 @@ module Hashie
     # Set the mode of both the save file and backup file.
     def set_mode
       # Why are we trying to set_mode when we don't even have a file?
-      return false if !@file
+      return false unless @file
       File.chmod @mode, @file if File.exist? @file
 
       # the backup file may not exist for whatever reason, lets not shit if it doesn't.
-      return true if !backup_file
+      return true unless backup_file
       File.chmod @mode, backup_file if File.exist? backup_file
       true
     end
@@ -102,10 +101,9 @@ module Hashie
 
     # Delete the save file.
     def delete_file
-      return false if !@file
+      return false unless @file
       FileUtils.rm @file if File.file? @file
-      return true
+      true
     end
   end
 end
-

--- a/lib/hashie/sash.rb
+++ b/lib/hashie/sash.rb
@@ -1,0 +1,109 @@
+require 'fileutils'
+require 'yaml'
+
+module Hashie
+  # This is a savable hash, it can be configured and used to store whatever the# contents of the hash are for loading later.  Will serialize in yaml to keep all
+  # the dependencies in ruby stdlib.
+  class Sash < Hash
+
+    attr_accessor :file
+    attr_accessor :backup
+    attr_accessor :mode
+    attr_accessor :auto_load
+    attr_accessor :auto_save
+
+    # overrides:{Hash.new}
+    # options: Sash options.
+    def initialize(params = {})
+      # if we get any params not listed above, throw an exception.
+      p = params.select { |k,v| k != :options && k != :overrides}
+      raise ArgumentError, "Extra values passed in: #{p}" if p.count > 0
+
+      # set our options to our attributes.
+      params[:options].each { |k,v| instance_variable_set "@" + k.to_s,v} if params[:options]
+
+      # should we load our data?
+      load if @auto_load
+
+      # did we get any overrides?
+      self.merge! params[:overrides] if params[:overrides]
+
+      return self
+    end
+
+    # The base directory of the save file.
+    def basedir
+      return nil if !file
+      File.dirname File.absolute_path @file
+    end
+
+    # The save file plus an extension.
+    def backup_file
+      "#{@file}.bak"
+    end
+
+    # Save the hash to the file, check for backup and set_mode.
+    def save
+      if any?
+        FileUtils.mkdir_p basedir if !Dir.exist? basedir
+        backup if @backup
+
+        # I do this the long way because I want an immediate sync.
+        f = open(@file, 'w')
+        f.write YAML::dump self
+        f.sync
+        f.close
+
+        set_mode if @mode
+      end
+      true
+    end
+    # Store a value in the Hash.  Can autosave.
+    def []=(key,value)
+      store key, value
+      save! if @auto_save == true
+    end
+    # Save the hash to a file, overwriting if necessary.
+    def save!
+      delete_file
+      save
+    end
+
+    # Load the save file into self.
+    def load
+      self.clear
+      if @file && File.exist?(@file) && File.stat(@file).size > 0
+        h = YAML::load open(@file, 'r').read
+        h.each { |k,v| self[k] = v}
+      end
+      return self
+    end
+
+    # Generate a backup file real quick.
+    def backup
+      FileUtils.cp @file, backup_file if File.file? @file
+    end
+
+    # Set the mode of both the save file and backup file.
+    def set_mode
+      # Why are we trying to set_mode when we don't even have a file?
+      return false if !@file
+      File.chmod @mode, @file if File.exist? @file
+
+      # the backup file may not exist for whatever reason, lets not shit if it doesn't.
+      return true if !backup_file
+      File.chmod @mode, backup_file if File.exist? backup_file
+      true
+    end
+
+    private
+
+    # Delete the save file.
+    def delete_file
+      return false if !@file
+      FileUtils.rm @file if File.file? @file
+      return true
+    end
+  end
+end
+

--- a/lib/hashie/sash.rb
+++ b/lib/hashie/sash.rb
@@ -15,9 +15,11 @@ module Hashie
     # overrides:{Hash.new}
     # options: Sash options.
     def initialize(params = {})
-      # if we get any params not listed above, throw an exception.
+      # Throw an exception if we get anything more then the two named hash keys.
+      # This is to prevent usage errors (you can't initialize a sash quite like
+      # a hash since it takes options or overrides.)
       p = params.select { |k,v| k != :options && k != :overrides}
-      raise ArgumentError, "Extra values passed in: #{p}" if p.count > 0
+      raise ArgumentError, "Extra values passed in: #{p}." if p.count > 0
 
       # set our options to our attributes.
       params[:options].each { |k,v| instance_variable_set "@" + k.to_s,v} if params[:options]

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -53,11 +53,11 @@ describe DashTest do
 
   subject { DashTest.new(first_name: 'Bob', email: 'bob@example.com') }
 
-  it('subclasses Hashie::Hash') { should respond_to(:to_mash) }
+  it('subclasses Hashie::Hash') { is_expected.to respond_to(:to_mash) }
 
   describe '#to_s' do
     subject { super().to_s }
-    it { should eq '#<DashTest count=0 email="bob@example.com" first_name="Bob">' }
+    it { is_expected.to eq '#<DashTest count=0 email="bob@example.com" first_name="Bob">' }
   end
 
   it 'lists all set properties in inspect' do
@@ -68,12 +68,12 @@ describe DashTest do
 
   describe '#count' do
     subject { super().count }
-    it { should be_zero }
+    it { is_expected.to be_zero }
   end
 
-  it { should respond_to(:first_name) }
-  it { should respond_to(:first_name=) }
-  it { should_not respond_to(:nonexistent) }
+  it { is_expected.to respond_to(:first_name) }
+  it { is_expected.to respond_to(:first_name=) }
+  it { is_expected.not_to respond_to(:nonexistent) }
 
   it 'errors out for a non-existent property' do
     expect { subject['nonexistent'] }.to raise_error(*no_property_error('nonexistent'))
@@ -379,13 +379,13 @@ describe SubclassedTest do
 
   describe '#count' do
     subject { super().count }
-    it { should be_zero }
+    it { is_expected.to be_zero }
   end
 
-  it { should respond_to(:first_name) }
-  it { should respond_to(:first_name=) }
-  it { should respond_to(:last_name) }
-  it { should respond_to(:last_name=) }
+  it { is_expected.to respond_to(:first_name) }
+  it { is_expected.to respond_to(:first_name=) }
+  it { is_expected.to respond_to(:last_name) }
+  it { is_expected.to respond_to(:last_name=) }
 
   it 'has one additional property' do
     expect(described_class.property?(:last_name)).to be_truthy
@@ -404,8 +404,8 @@ end
 describe MixedPropertiesTest do
   subject { MixedPropertiesTest.new('string' => 'string', symbol: 'symbol') }
 
-  it { should respond_to('string') }
-  it { should respond_to(:symbol) }
+  it { is_expected.to respond_to('string') }
+  it { is_expected.to respond_to(:symbol) }
 
   it 'property?' do
     expect(described_class.property?('string')).to be_truthy

--- a/spec/hashie/sash_spec.rb
+++ b/spec/hashie/sash_spec.rb
@@ -1,95 +1,90 @@
 require 'spec_helper'
 
 describe Hashie::Sash do
-	before (:all) do
-		FileUtils.mkdir_p 'tmp'
-	end
+  before(:all) do
+    FileUtils.mkdir_p 'tmp'
+  end
 
-	before (:each) do
-		@filename = "tmp/sash_savefile.yaml"
-		@s = Hashie::Sash.new options:{file:@filename}
-		@s[:before_each] = true
-	end
+  before(:each) do
+    @filename = 'tmp/sash_savefile.yaml'
+    @s = Hashie::Sash.new(options: { file: @filename })
+    @s[:before_each] = true
+  end
 
-	after (:all) do
-		FileUtils.rm @filename if @filename
-	end
+  after(:all) do
+    FileUtils.rm @filename if @filename
+  end
 
-	it "Can pass overrides via overrides:{}" do
-		@s2 = Hashie::Sash.new(overrides:{foo: :bar})
-		@s2.should  include(:foo)
-	end
+  it 'Can pass overrides via overrides:{}' do
+    @s2 = Hashie::Sash.new(overrides: { foo: :bar })
+    @s2.should include(:foo)
+  end
 
-	it 'will fail gracefully if nothing to load.' do
-		@s.save
-		FileUtils.rm @filename
-		@s.load.should be {}
-		@s.file = nil
-		@s.load.should be {}
-		FileUtils.touch @filename
-		@s.load.should be {}
-	end
-	it "will raise an exception if you pass in unknown arguments to new." do
-		@s2 = expect { Sash.new(foo:'bar') }.to raise_error
-	end
+  it 'will fail gracefully if nothing to load.' do
+    @s.save
+    FileUtils.rm @filename
+    @s.load.should be {}
+    @s.file = nil
+    @s.load.should be {}
+    FileUtils.touch @filename
+    @s.load.should be {}
+  end
 
-	describe "Saving" do
-		it "can save" do
-			@s['foo'] = :bar
-			@s.save
-			@s2 = Hashie::Sash.new options:{file:@filename}
-			@s2.load
-			@s2['foo'].should eq :bar
-		end
+  it 'will raise an exception if you pass in unknown arguments to new.' do
+    @s2 = expect { Sash.new(foo: 'bar') }.to raise_error
+  end
 
+  describe 'Saving' do
+    it 'can save' do
+      @s['foo'] = :bar
+      @s.save
+      @s2 = Hashie::Sash.new(options: { file: @filename })
+      @s2.load
+      @s2['foo'].should eq :bar
+    end
 
-		it "can set the mode" do
-			@s.mode = 0600
-			@s.set_mode
-			@s.save
-			# I have no idea why you put in 0600, 0600 becomes 384, and out comes 33152.
-			# when I figure out where the conversion is going wrong, I'll update this.
-			File.stat(@s.file).mode.should eq 33152
-		end
+    it 'can set the mode' do
+      @s.mode = 0600
+      @s.set_mode
+      @s.save
+      # I have no idea why you put in 0600, 0600 becomes 384, and out comes 33152.
+      # when I figure out where the conversion is going wrong, I'll update this.
+      File.stat(@s.file).mode.should eq 33_152
+    end
 
+    it 'can auto save' do
+      @s = Hashie::Sash.new(options: { file: @filename, auto_save: true })
+      @s[:auto_save] = true
+      @s2 = Hashie::Sash.new(options: { file: @filename })
+      @s2.load
+      @s2[:auto_save].should be true
+    end
 
-		it "can auto save" do
-			@s = Hashie::Sash.new options:{file:@filename, auto_save:true}
-			@s[:auto_save] = true
-			@s2 = Hashie::Sash.new options:{file:@filename}
-			@s2.load
-			@s2[:auto_save].should be true
-		end
+    it 'can auto load' do
+      @s[:auto_load] = true
+      @s.save
+      @s2 = Hashie::Sash.new(options: { file: @filename, auto_load: true })
+      @s2[:auto_load].should be true
+    end
 
-		it "can auto load" do
-			@s[:auto_load] = true
-			@s.save
-			@s2 = Hashie::Sash.new options:{file:@filename, auto_load:true}
-			@s2[:auto_load].should be true
-		end
+    # We save twice because in order to produce a backup file, we need an original.
+    it 'can make a backup file' do
+      @s.backup = true
+      @s[:backup] = 'something'
+      @s.save
+      @s.save
+      File.exist?(@s.backup_file).should eq(true)
+    end
 
-		# We save twice because in order to produce a backup file, we need an original.
-		it "can make a backup file" do
-			@s.backup = true
-			@s[:backup] = "something"
-			@s.save
-			@s.save
-			File.exist?(@s.backup_file).should be_true
-		end
+    it 'will clear before load, destroying previous contents' do
+      @s[:clear] = 'clear'
+      @s.load
+      @s[:clear].should be_nil
+    end
+  end
 
-		it "will clear before load, destroying previous contents" do
-			@s[:clear] = 'clear'
-			@s.load
-			@s[:clear].should be_nil
-		end
-	end
-
-	it "will behave like a normal Hash" do
-		@s.kind_of?(Hash).should be_true
-	end
+  it 'will behave like a normal Hash' do
+    @s.kind_of?(Hash).should eq(true)
+  end
 
 end
-
-
-
-

--- a/spec/hashie/sash_spec.rb
+++ b/spec/hashie/sash_spec.rb
@@ -17,17 +17,17 @@ describe Hashie::Sash do
 
   it 'Can pass overrides via overrides:{}' do
     @s2 = Hashie::Sash.new(overrides: { foo: :bar })
-    @s2.should include(:foo)
+    expect(@s2).to include(:foo)
   end
 
   it 'will fail gracefully if nothing to load.' do
     @s.save
     FileUtils.rm @filename
-    @s.load.should be {}
+    expect(@s.load).to be {}
     @s.file = nil
-    @s.load.should be {}
+    expect(@s.load).to be {}
     FileUtils.touch @filename
-    @s.load.should be {}
+    expect(@s.load).to be {}
   end
 
   it 'will raise an exception if you pass in unknown arguments to new.' do
@@ -40,7 +40,7 @@ describe Hashie::Sash do
       @s.save
       @s2 = Hashie::Sash.new(options: { file: @filename })
       @s2.load
-      @s2['foo'].should eq :bar
+      expect(@s2['foo']).to eq :bar
     end
 
     it 'can set the mode' do
@@ -49,7 +49,7 @@ describe Hashie::Sash do
       @s.save
       # I have no idea why you put in 0600, 0600 becomes 384, and out comes 33152.
       # when I figure out where the conversion is going wrong, I'll update this.
-      File.stat(@s.file).mode.should eq 33_152
+      expect(File.stat(@s.file).mode).to eq 33_152
     end
 
     it 'can auto save' do
@@ -57,14 +57,14 @@ describe Hashie::Sash do
       @s[:auto_save] = true
       @s2 = Hashie::Sash.new(options: { file: @filename })
       @s2.load
-      @s2[:auto_save].should be true
+      expect(@s2[:auto_save]).to be true
     end
 
     it 'can auto load' do
       @s[:auto_load] = true
       @s.save
       @s2 = Hashie::Sash.new(options: { file: @filename, auto_load: true })
-      @s2[:auto_load].should be true
+      expect(@s2[:auto_load]).to be true
     end
 
     # We save twice because in order to produce a backup file, we need an original.
@@ -73,18 +73,18 @@ describe Hashie::Sash do
       @s[:backup] = 'something'
       @s.save
       @s.save
-      File.exist?(@s.backup_file).should eq(true)
+      expect(File.exist?(@s.backup_file)).to eq(true)
     end
 
     it 'will clear before load, destroying previous contents' do
       @s[:clear] = 'clear'
       @s.load
-      @s[:clear].should be_nil
+      expect(@s[:clear]).to be_nil
     end
   end
 
   it 'will behave like a normal Hash' do
-    @s.kind_of?(Hash).should eq(true)
+    expect(@s.kind_of?(Hash)).to eq(true)
   end
 
 end

--- a/spec/hashie/sash_spec.rb
+++ b/spec/hashie/sash_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Bini::Sash do
+	before (:all) do
+		FileUtils.mkdir_p 'tmp'
+	end
+
+	before (:each) do
+		@filename = "tmp/sash_savefile.yaml"
+		@s = Bini::Sash.new options:{file:@filename}
+		@s[:before_each] = true
+	end
+
+	after (:all) do
+		FileUtils.rm @filename if @filename
+	end
+
+	it "Can pass overrides via overrides:{}" do
+		@s2 = Bini::Sash.new(overrides:{foo: :bar})
+		@s2.should  include(:foo)
+	end
+
+	it 'will fail gracefully if nothing to load.' do
+		@s.save
+		FileUtils.rm @filename
+		@s.load.should be {}
+		@s.file = nil
+		@s.load.should be {}
+		FileUtils.touch @filename
+		@s.load.should be {}
+	end
+	it "will raise an exception if you pass in unknown arguments to new." do
+		@s2 = expect { Sash.new(foo:'bar') }.to raise_error
+	end
+
+	describe "Saving" do
+		it "can save" do
+			@s['foo'] = :bar
+			@s.save
+			@s2 = Bini::Sash.new options:{file:@filename}
+			@s2.load
+			@s2['foo'].should eq :bar
+		end
+
+
+		it "can set the mode" do
+			@s.mode = 0600
+			@s.set_mode
+			@s.save
+			# I have no idea why you put in 0600, 0600 becomes 384, and out comes 33152.
+			# when I figure out where the conversion is going wrong, I'll update this.
+			File.stat(@s.file).mode.should eq 33152
+		end
+
+
+		it "can auto save" do
+			@s = Bini::Sash.new options:{file:@filename, auto_save:true}
+			@s[:auto_save] = true
+			@s2 = Bini::Sash.new options:{file:@filename}
+			@s2.load
+			@s2[:auto_save].should be true
+		end
+
+		it "can auto load" do
+			@s[:auto_load] = true
+			@s.save
+			@s2 = Bini::Sash.new options:{file:@filename, auto_load:true}
+			@s2[:auto_load].should be true
+		end
+
+		# We save twice because in order to produce a backup file, we need an original.
+		it "can make a backup file" do
+			@s.backup = true
+			@s[:backup] = "something"
+			@s.save
+			@s.save
+			File.exist?(@s.backup_file).should be_true
+		end
+
+		it "will clear before load, destroying previous contents" do
+			@s[:clear] = 'clear'
+			@s.load
+			@s[:clear].should be_nil
+		end
+	end
+
+	it "will behave like a normal Hash" do
+		@s.kind_of?(Hash).should be_true
+	end
+
+end
+
+
+
+

--- a/spec/hashie/sash_spec.rb
+++ b/spec/hashie/sash_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe Bini::Sash do
+describe Hashie::Sash do
 	before (:all) do
 		FileUtils.mkdir_p 'tmp'
 	end
 
 	before (:each) do
 		@filename = "tmp/sash_savefile.yaml"
-		@s = Bini::Sash.new options:{file:@filename}
+		@s = Hashie::Sash.new options:{file:@filename}
 		@s[:before_each] = true
 	end
 
@@ -16,7 +16,7 @@ describe Bini::Sash do
 	end
 
 	it "Can pass overrides via overrides:{}" do
-		@s2 = Bini::Sash.new(overrides:{foo: :bar})
+		@s2 = Hashie::Sash.new(overrides:{foo: :bar})
 		@s2.should  include(:foo)
 	end
 
@@ -37,7 +37,7 @@ describe Bini::Sash do
 		it "can save" do
 			@s['foo'] = :bar
 			@s.save
-			@s2 = Bini::Sash.new options:{file:@filename}
+			@s2 = Hashie::Sash.new options:{file:@filename}
 			@s2.load
 			@s2['foo'].should eq :bar
 		end
@@ -54,9 +54,9 @@ describe Bini::Sash do
 
 
 		it "can auto save" do
-			@s = Bini::Sash.new options:{file:@filename, auto_save:true}
+			@s = Hashie::Sash.new options:{file:@filename, auto_save:true}
 			@s[:auto_save] = true
-			@s2 = Bini::Sash.new options:{file:@filename}
+			@s2 = Hashie::Sash.new options:{file:@filename}
 			@s2.load
 			@s2[:auto_save].should be true
 		end
@@ -64,7 +64,7 @@ describe Bini::Sash do
 		it "can auto load" do
 			@s[:auto_load] = true
 			@s.save
-			@s2 = Bini::Sash.new options:{file:@filename, auto_load:true}
+			@s2 = Hashie::Sash.new options:{file:@filename, auto_load:true}
 			@s2[:auto_load].should be true
 		end
 


### PR DESCRIPTION
On top of @erniebrodeur original Sash work:
1. Addressed a number of Rubocop violations
2. Used transpec to bring RSpec syntax up to 3.0.x compliance
3. Fixed argument syntax to be Ruby 1.8.7 compliant
