### PR TITLE
Fix #202 by stopping method redefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#200](https://github.com/intridea/hashie/pull/200): Improved coercion: primitives and error handling - [@maxlinc](https://github.com/maxlinc).
 * [#204](https://github.com/intridea/hashie/pull/204): Added Hashie::Extensions::MethodOverridingWriter and Hashie::Extensions::MethodAccessWithOverride - [@michaelherold](https://github.com/michaelherold).
 * [#205](http://github.com/intridea/hashie/pull/205): Added Hashie::Extensions::Mash::SafeAssignment - [@michaelherold](https://github.com/michaelherold).
+* [#206](http://github.com/intridea/hashie/pull/206): Fixed stack overflow from repetitively including coercion in subclasses - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## 3.2.0 (7/10/2014)

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -21,8 +21,8 @@ module Hashie
         base.send :include, InstanceMethods
         base.extend ClassMethods # NOTE: we wanna make sure we first define set_value_with_coercion before extending
 
-        base.send :alias_method, :'set_value_without_coercion', :[]=
-        base.send :alias_method, :[]=, :'set_value_with_coercion'
+        base.send :alias_method, :set_value_without_coercion, :[]= unless base.method_defined?(:set_value_without_coercion)
+        base.send :alias_method, :[]=, :set_value_with_coercion
       end
 
       module InstanceMethods

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -62,12 +62,12 @@ describe Hashie::Extensions::Coercion do
       subject { RootCoercableHash }
       let(:instance) { subject.new }
 
-      it 'coeces nested objects' do
+      it 'coerces nested objects' do
         instance[:nested] = { foo: 123, bar: '456' }
         test_nested_object(instance[:nested])
       end
 
-      it 'coeces nested arrays' do
+      it 'coerces nested arrays' do
         instance[:nested_list] = [
           { foo: 123, bar: '456' },
           { foo: 234, bar: '567' },
@@ -80,7 +80,7 @@ describe Hashie::Extensions::Coercion do
         end
       end
 
-      it 'coeces nested hashes' do
+      it 'coerces nested hashes' do
         instance[:nested_hash] = {
           a: { foo: 123, bar: '456' },
           b: { foo: 234, bar: '567' },
@@ -91,6 +91,25 @@ describe Hashie::Extensions::Coercion do
         instance[:nested_hash].each do | key, nested |
           expect(key).to be_a(String)
           test_nested_object nested
+        end
+      end
+
+      context 'when repetitively including the module' do
+        class RepetitiveCoercableHash < NestedCoercableHash
+          include Hashie::Extensions::Coercion
+          include Hashie::Extensions::MergeInitializer
+
+          coerce_key :nested, NestedCoercableHash
+        end
+
+        subject { RepetitiveCoercableHash }
+        let(:instance) { subject.new }
+
+        it 'does not raise a stack overflow error' do
+          expect do
+            instance[:nested] = { foo: 123, bar: '456' }
+            test_nested_object(instance[:nested])
+          end.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
The stack overflow was caused by recursively redefining `#set_value_without_coercion` in nested subclasses that include the Coercion extension. Checking to see if that method is already defined stops that issue from occurring.
