### PR TITLE
Add spec from #112 for Trash subclasses

### DIFF
--- a/spec/hashie/trash_spec.rb
+++ b/spec/hashie/trash_spec.rb
@@ -252,4 +252,18 @@ describe Hashie::Trash do
       end
     end.to raise_error(ArgumentError)
   end
+
+  context 'when subclassing' do
+    class Person < Hashie::Trash
+      property :first_name, from: :firstName
+    end
+
+    class Hobbit < Person; end
+
+    subject { Hobbit.new(firstName: 'Frodo') }
+
+    it 'keeps translation definitions in subclasses' do
+      expect(subject.first_name).to eq('Frodo')
+    end
+  end
 end


### PR DESCRIPTION
#112 stated that Trashes were not keeping their parent's translations when subclassing a Trash. Currently, it's an old issue that seems to have been fixed since it was originally filed. I thought it would be good to have a spec specifically for this issue, to make sure the functionality doesn't break in the future.
