### PR TITLE
Object allocation during parsing method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next Release
 
 * Your contribution here.
+* [#221](https://github.com/intridea/hashie/pull/221): Reduce amount of allocated objects on calls with suffixes in Hashie::Mash - [@kubum](https://github.com/kubum).
 
 ## 3.3.1 (8/26/2014)
 

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -58,6 +58,7 @@ module Hashie
     include Hashie::Extensions::PrettyInspect
 
     ALLOWED_SUFFIXES = %w(? ! = _)
+    SUFFIXES_PARSER  = /(.*?)([#{ALLOWED_SUFFIXES.join}]?)$/
 
     def self.load(path, options = {})
       @_mashes ||= new do |h, file_path|
@@ -251,8 +252,7 @@ module Hashie
     protected
 
     def method_suffix(method_name)
-      suffixes_regex = ALLOWED_SUFFIXES.join
-      match = method_name.to_s.match(/(.*?)([#{suffixes_regex}]?)$/)
+      match = method_name.to_s.match(SUFFIXES_PARSER)
       [match[1], match[2]]
     end
 


### PR DESCRIPTION
Hey everyone!

One day we decided to profile our rails application where we heavily rely on ElasticSearch and Hashie.

I had a look into "Allocated String Report" and noticed that we have allocated the same string `(.*?)([?!=_]?)$`  _50 000 times_, and then I noticed that it's inside `Hashie::Mash`.

This pull-request reduces amount of allocated objects on calls with suffixes.

Benchmark code:

``` ruby
mash = Hashie::Mash.new
mash.let = 'store'

N = 1000000

before = GC.stat(:total_allocated_object)
N.times { mash.let? }
after  = GC.stat(:total_allocated_object)

puts (after - before) / N
puts GC.stat
```

Before change:

```
18
{:count=>670, :heap_used=>145, :heap_length=>145, :heap_increment=>0, :heap_live_slot=>58961, :heap_free_slot=>138, :heap_final_slot=>0, :heap_swept_slot=>21984, :heap_eden_page_length=>145, :heap_tomb_page_length=>0, :total_allocated_object=>18219623, :total_freed_object=>18160662, :malloc_increase=>18656, :malloc_limit=>16777216, :minor_gc_count=>667, :major_gc_count=>3, :remembered_shady_object=>426, :remembered_shady_object_limit=>574, :old_object=>31820, :old_object_limit=>42556, :oldmalloc_increase=>2044464, :oldmalloc_limit=>16777216}
```

After change:

```
9
{:count=>319, :heap_used=>145, :heap_length=>145, :heap_increment=>0, :heap_live_slot=>59035, :heap_free_slot=>68, :heap_final_slot=>0, :heap_swept_slot=>2923, :heap_eden_page_length=>145, :heap_tomb_page_length=>0, :total_allocated_object=>9219622, :total_freed_object=>9160587, :malloc_increase=>10544, :malloc_limit=>16777216, :minor_gc_count=>316, :major_gc_count=>3, :remembered_shady_object=>424, :remembered_shady_object_limit=>574, :old_object=>27789, :old_object_limit=>42554, :oldmalloc_increase=>1019152, :oldmalloc_limit=>16777216}
```

Twice less allocated objects for checking the existence, also no more recreation of constant string after every method access.

Would be happy to hear any feedback! 
