### PR TITLE
Merging Hashie::Mash now correctly only calls the block on duplicate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next Release
 
 * Your contribution here.
+* [#224](https://github.com/intridea/hashie/pull/224): Merging Hashie::Mash now correctly only calls the block on duplicate values - [@amysutedja](https://github.com/amysutedja).
 * [#221](https://github.com/intridea/hashie/pull/221): Reduce amount of allocated objects on calls with suffixes in Hashie::Mash - [@kubum](https://github.com/kubum).
 
 ## 3.3.1 (8/26/2014)

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -37,7 +37,7 @@ module Hashie
         defaults.delete property_name
       end
 
-      unless instance_methods.map { |m| m.to_s }.include?("#{property_name}=")
+      unless instance_methods.map(&:to_s).include?("#{property_name}=")
         define_method(property_name) { |&block| self.[](property_name, &block) }
         property_assignment = property_name.to_s.concat('=').to_sym
         define_method(property_assignment) { |value| self.[]=(property_name, value) }

--- a/lib/hashie/extensions/method_access.rb
+++ b/lib/hashie/extensions/method_access.rb
@@ -172,7 +172,7 @@ module Hashie
       end
 
       def method?(name)
-        methods.map { |m| m.to_s }.include?(name)
+        methods.map(&:to_s).include?(name)
       end
 
       def redefine_method(method_name)

--- a/lib/hashie/extensions/pretty_inspect.rb
+++ b/lib/hashie/extensions/pretty_inspect.rb
@@ -8,7 +8,7 @@ module Hashie
 
       def hashie_inspect
         ret = "#<#{self.class}"
-        keys.sort_by { |key| key.to_s }.each do |key|
+        keys.sort_by(&:to_s).each do |key|
           ret << " #{key}=#{self[key].inspect}"
         end
         ret << '>'

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -181,7 +181,7 @@ module Hashie
           custom_reader(key).deep_update(v, &blk)
         else
           value = convert_value(v, true)
-          value = convert_value(blk.call(key, self[k], value), true) if blk
+          value = convert_value(blk.call(key, self[k], value), true) if blk && self.key?(k)
           custom_writer(key, value, false)
         end
       end

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -269,7 +269,7 @@ describe DashTest do
     end
 
     it 'leaves only specified keys and keys with default values' do
-      expect(subject.keys.sort_by { |key| key.to_s }).to eq [:count, :first_name]
+      expect(subject.keys.sort_by(&:to_s)).to eq [:count, :first_name]
       expect(subject.email).to be_nil
       expect(subject.count).to eq 0
     end

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -160,7 +160,7 @@ describe Hashie::Extensions::Coercion do
 
       instance[:foo] = %w('bar', 'bar2')
       expect(instance[:foo].map(&:value)).to all(eq 'String')
-      expect(instance[:foo]).to be_none { |v| v.coerced? }
+      expect(instance[:foo]).to be_none(&:coerced?)
       expect(instance[:foo]).to be_a(Set)
     end
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -189,6 +189,12 @@ describe Hashie::Mash do
         duped = subject.merge(details: { address: 'Pasadena CA' }) { |_, oldv, newv| [oldv, newv].join(', ') }
         expect(duped.details.address).to eq 'Nowhere road, Pasadena CA'
       end
+
+      it 'copies values for non-duplicate keys when a block is supplied' do
+        duped = subject.merge(details: { address: 'Pasadena CA', state: 'West Thoughtleby' }) { |_, oldv, _| oldv }
+        expect(duped.details.address).to eq 'Nowhere road'
+        expect(duped.details.state).to eq 'West Thoughtleby'
+      end
     end
 
     describe 'shallow update' do


### PR DESCRIPTION
The spec for `Hash#merge!` states:

```
Adds the contents of other_hash to hsh. If no block is specified, entries with duplicate keys are overwritten with the values from other_hash, otherwise the value of each duplicate key is determined by calling the block with the key, its value in hsh and its value in other_hash.
```

This changeset causes blocks passed to `Hashie::Mash#deep_update` to only run on duplicate keys.
