### PR TITLE
Bump rubocop to 0.26 and address new cops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 group :development do
   gem 'pry'
   gem 'pry-stack_explorer', platforms: [:ruby_19, :ruby_20, :ruby_21]
-  gem 'rubocop', '~> 0.25'
+  gem 'rubocop', '~> 0.26'
   gem 'guard', '~> 2.6.1'
   gem 'guard-rspec', '~> 4.3.1', require: false
 end

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -37,7 +37,7 @@ module Hashie
         defaults.delete property_name
       end
 
-      unless instance_methods.map { |m| m.to_s }.include?("#{property_name}=")
+      unless instance_methods.map(&:to_s).include?("#{property_name}=")
         define_method(property_name) { |&block| self.[](property_name, &block) }
         property_assignment = property_name.to_s.concat('=').to_sym
         define_method(property_assignment) { |value| self.[]=(property_name, value) }

--- a/lib/hashie/extensions/method_access.rb
+++ b/lib/hashie/extensions/method_access.rb
@@ -172,7 +172,7 @@ module Hashie
       end
 
       def method?(name)
-        methods.map { |m| m.to_s }.include?(name)
+        methods.map(&:to_s).include?(name)
       end
 
       def redefine_method(method_name)

--- a/lib/hashie/extensions/pretty_inspect.rb
+++ b/lib/hashie/extensions/pretty_inspect.rb
@@ -8,7 +8,7 @@ module Hashie
 
       def hashie_inspect
         ret = "#<#{self.class}"
-        keys.sort_by { |key| key.to_s }.each do |key|
+        keys.sort_by(&:to_s).each do |key|
           ret << " #{key}=#{self[key].inspect}"
         end
         ret << '>'

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -269,7 +269,7 @@ describe DashTest do
     end
 
     it 'leaves only specified keys and keys with default values' do
-      expect(subject.keys.sort_by { |key| key.to_s }).to eq [:count, :first_name]
+      expect(subject.keys.sort_by(&:to_s)).to eq [:count, :first_name]
       expect(subject.email).to be_nil
       expect(subject.count).to eq 0
     end

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -160,7 +160,7 @@ describe Hashie::Extensions::Coercion do
 
       instance[:foo] = %w('bar', 'bar2')
       expect(instance[:foo].map(&:value)).to all(eq 'String')
-      expect(instance[:foo]).to be_none { |v| v.coerced? }
+      expect(instance[:foo]).to be_none(&:coerced?)
       expect(instance[:foo]).to be_a(Set)
     end
 


### PR DESCRIPTION
The pertinent new cop is the `SymbolProc` cop, which encourages you to pass a symbol instead of a block when simply calling a method on the block parameter. It makes the code a little easier to parse to me, so I thought I'd keep it. Thoughts anyone?
