### PR TITLE
README.md: Fixed issue in deep_merge example

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,8 @@ class MyHash < Hash
   include Hashie::Extensions::DeepMerge
 end
 
-h1 = MyHash.new
-h2 = MyHash.new
-
-h1 = { x: { y: [4,5,6] }, z: [7,8,9] }
-h2 = { x: { y: [7,8,9] }, z: "xyz" }
+h1 = MyHash[{ x: { y: [4,5,6] }, z: [7,8,9] }]
+h2 = MyHash[{ x: { y: [7,8,9] }, z: "xyz" }]
 
 h1.deep_merge(h2) # => { x: { y: [7, 8, 9] }, z: "xyz" }
 h2.deep_merge(h1) # => { x: { y: [4, 5, 6] }, z: [7, 8, 9] }


### PR DESCRIPTION
The way it was written doesn't work, because h1 and h2 will be standard Hashes (not MyHashes) that don't have the deep_merge method.
