### PR TITLE
Autoload MethodAccessWithOverride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [#228](https://github.com/intridea/hashie/pull/228): Made Hashie::Extensions::Parsers::YamlErbParser pass template filename to ERB - [@jperville](https://github.com/jperville).
 * [#224](https://github.com/intridea/hashie/pull/224): Merging Hashie::Mash now correctly only calls the block on duplicate values - [@amysutedja](https://github.com/amysutedja).
 * [#221](https://github.com/intridea/hashie/pull/221): Reduce amount of allocated objects on calls with suffixes in Hashie::Mash - [@kubum](https://github.com/kubum).
-* Your contribution here.
+* [#245](https://github.com/intridea/hashie/pull/245): Add Hashie::Extensions::MethodAccessWithOverride to hashie.rb autoloads - [@Fritzinger](https://github.com/Fritzinger).
 
 ## 3.3.1 (8/26/2014)
 

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -24,6 +24,7 @@ module Hashie
     autoload :DeepFind,          'hashie/extensions/deep_find'
     autoload :PrettyInspect,     'hashie/extensions/pretty_inspect'
     autoload :KeyConversion,     'hashie/extensions/key_conversion'
+    autoload :MethodAccessWithOverride, 'hashie/extensions/method_access'
 
     module Parsers
       autoload :YamlErbParser, 'hashie/extensions/parsers/yaml_erb_parser'

--- a/spec/hashie/extensions/autoload_spec.rb
+++ b/spec/hashie/extensions/autoload_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'hashie'
+
+describe Hashie::Extensions do
+  describe 'autloads constants' do
+    it { is_expected.to be_const_defined(:MethodAccess) }
+    it { is_expected.to be_const_defined(:Coercion) }
+    it { is_expected.to be_const_defined(:DeepMerge) }
+    it { is_expected.to be_const_defined(:IgnoreUndeclared) }
+    it { is_expected.to be_const_defined(:IndifferentAccess) }
+    it { is_expected.to be_const_defined(:MergeInitializer) }
+    it { is_expected.to be_const_defined(:MethodAccess) }
+    it { is_expected.to be_const_defined(:MethodQuery) }
+    it { is_expected.to be_const_defined(:MethodReader) }
+    it { is_expected.to be_const_defined(:MethodWriter) }
+    it { is_expected.to be_const_defined(:StringifyKeys) }
+    it { is_expected.to be_const_defined(:SymbolizeKeys) }
+    it { is_expected.to be_const_defined(:DeepFetch) }
+    it { is_expected.to be_const_defined(:DeepFind) }
+    it { is_expected.to be_const_defined(:PrettyInspect) }
+    it { is_expected.to be_const_defined(:KeyConversion) }
+    it { is_expected.to be_const_defined(:MethodAccessWithOverride) }
+  end
+end


### PR DESCRIPTION
Added MethodAccessWithOverride to autoloads in hashie.rb. See https://github.com/intridea/hashie/issues/244

Also added autoload_spec which tests whether all the other extensions are autoloaded too.
