### PR TITLE
Clash: cannot nest twice even when key is Clash class

### DIFF
--- a/lib/hashie/clash.rb
+++ b/lib/hashie/clash.rb
@@ -54,7 +54,9 @@ module Hashie
       case args.length
       when 1
         val = args.first
-        val = self[key].merge(val) if self[key].is_a?(::Hash) && val.is_a?(::Hash)
+        if self[key].is_a?(::Hash) && val.is_a?(::Hash)
+          val = self.class.new(self[key]).merge(val)
+        end
       else
         val = args
       end
@@ -64,22 +66,23 @@ module Hashie
     end
 
     def method_missing(name, *args) #:nodoc:
-      name = name.to_s
-      if name.match(/!$/) && args.empty?
+      if args.empty? && name.to_s.end_with?('!')
         key = name[0...-1].to_sym
 
-        if self[key].nil?
-          self[key] = Clash.new({}, self)
-        elsif self[key].is_a?(::Hash) && !self[key].is_a?(Clash)
-          self[key] = Clash.new(self[key], self)
+        case self[key]
+        when NilClass
+          self[key] = self.class.new({}, self)
+        when Clash
+          self[key]
+        when Hash
+          self[key] = self.class.new(self[key], self)
         else
           fail ChainError, 'Tried to chain into a non-hash key.'
         end
-
-        self[key]
       elsif args.any?
-        key = name.to_sym
-        merge_store(key, *args)
+        merge_store(name, *args)
+      else
+        super
       end
     end
   end

--- a/spec/hashie/clash_spec.rb
+++ b/spec/hashie/clash_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Hashie::Clash do
-  subject { Hashie::Clash.new }
-
   it 'is able to set an attribute via method_missing' do
     subject.foo('bar')
     expect(subject[:foo]).to eq 'bar'
@@ -44,5 +42,29 @@ describe Hashie::Clash do
     expect(subject).to eq(baz: 123, hgi: 123)
     expect(subject[:foo]).to be_nil
     expect(subject[:hello]).to be_nil
+  end
+
+  it 'merges multiple bang notation calls' do
+    subject.where!.foo(123)
+    subject.where!.bar(321)
+    expect(subject).to eq(where: { foo: 123, bar: 321 })
+  end
+
+  it 'raises an exception when method is missing' do
+    expect { subject.boo }.to raise_error(NoMethodError)
+  end
+
+  describe 'when inherited' do
+    subject { Class.new(described_class).new }
+
+    it 'bang nodes are instances of a subclass' do
+      subject.where!.foo(123)
+      expect(subject[:where]).to be_instance_of(subject.class)
+    end
+
+    it 'merged nodes are instances of a subclass' do
+      subject.where(abc: 'def').where(hgi: 123)
+      expect(subject[:where]).to be_instance_of(subject.class)
+    end
   end
 end


### PR DESCRIPTION
Hello,

In the example found in README:

https://github.com/intridea/hashie#clash

The suggestion to access one of the nested hashes is by using bang methods:

```ruby
c = Hashie::Clash.new
c.where!.nested(10)._end!
# => {:where=>{:nested=>10}}
```

However, a second attempt to do the same results in `ChainError` exception:

```ruby
c = Hashie::Clash.new
c.where!.nested(10)._end!
c.where!.another(10)._end!
Hashie::Clash::ChainError: Tried to chain into a non-hash key.
```

Of course this is a naive example, as the issue trying to solve is merge nested elements:

```ruby
c = Hashie::Clash.new
c.where(location: { near: [1, 2] })
# => {:where=>{:location=>{:near=>[1, 2]}}}
c.where(location: { distance: "100mi" })
# => {:where=>{:location=>{:distance=>"100mi"}}}
```

There is no way, without using the nested (bang) methods to workaround this limitation.

Looking at the logic of the code:

https://github.com/intridea/hashie/blob/59069f13ea067a319584a56674cc02de887b999f/lib/hashie/clash.rb#L73-L76

Seems that one scenario is missing, which is the case when `self[key]` is already a `Clash` instance.

Wanted to confirm if is the desired behavior, there are alternatives or a pull request might be in order :grin: 

Thank you!