### PR TITLE
non-obvious behaviour w/ Mash's []=

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -262,8 +262,6 @@ module Hashie
 
     def convert_value(val, duping = false) #:nodoc:
       case val
-      when self.class
-        val.dup
       when Hash
         duping ? val.dup : val
       when ::Hash

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -271,6 +271,12 @@ describe Hashie::Mash do
     expect(subject.details.address.state).to eq 'TX'
   end
 
+  it 'does not duplicate a Hashie::Hash object on assignment' do
+    my_hash = described_class.new
+    subject.foo = my_hash
+    expect(subject.foo).to equal(my_hash)
+  end
+
   it 'does not convert the type of Hashie::Mashes childs to Hashie::Mash' do
     class MyMash < Hashie::Mash
     end


### PR DESCRIPTION
Hi,

It wasn't obvious to me that the Mash `[]=` operator duplicates even Mashes.
Combined with the (also non-obvious) fact that `[]=` does not return the value actually stored (but the value assigned), this resulted in a hard-to-find bug in my code. For example:

``` ruby
x = Hashie::Mash.new
y = x[:k] = Hashie::Mash.new  # or {}
x[:k].equal? y  # false
```

I wonder whether the duplication of Mashes is necessary? And suggest that this behaviour be documented as a caveat. What do you think?

Thanks.

\- Felix
