### PR TITLE
Add block to indifferent access #fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#247](https://github.com/intridea/hashie/pull/247): Fixed #stringify_keys and #symbolize_keys collision with ActiveSupport - [@bartoszkopinski](https://github.com/bartoszkopinski).
 * [#249](https://github.com/intridea/hashie/pull/249): SafeAssignment will now also protect hash-style assignments - [@jrochkind](https://github.com/jrochkind).
+* [#251](https://github.com/intridea/hashie/pull/251): Add block to indifferent access #fetch - [@jgraichen](https://github.com/jgraichen).
 * Your contribution here.
 
 ## 3.3.2 (11/26/2014)

--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -107,8 +107,8 @@ module Hashie
         regular_writer convert_key(key), convert_value(value)
       end
 
-      def indifferent_fetch(key, *args)
-        regular_fetch convert_key(key), *args
+      def indifferent_fetch(key, *args, &block)
+        regular_fetch convert_key(key), *args, &block
       end
 
       def indifferent_delete(key)

--- a/spec/hashie/extensions/indifferent_access_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_spec.rb
@@ -108,6 +108,11 @@ describe Hashie::Extensions::IndifferentAccess do
         h = subject.build(foo: object)
         expect(h.fetch(:foo)).to be(object)
       end
+
+      it 'yields with key name if key does not exists' do
+        h = subject.build(a: 0)
+        expect(h.fetch(:foo) { |key| ['default for', key] }).to eq ['default for', 'foo']
+      end
     end
 
     describe '#delete' do


### PR DESCRIPTION
The `#fetch` method from `IndifferentAccess` did not pass a block to the underlying method which resulted in a KeyError on e.g.

``` ruby
indifferent_hash.fetch(:key) { |key| 'default value' }
```

This fix captures the block and passes it to the underlying fetch method that yields if the key cannot be found.
