### PR TITLE
Support for conditionally required Dash properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#247](https://github.com/intridea/hashie/pull/247): Fixed #stringify_keys and #symbolize_keys collision with ActiveSupport - [@bartoszkopinski](https://github.com/bartoszkopinski).
 * [#249](https://github.com/intridea/hashie/pull/249): SafeAssignment will now also protect hash-style assignments - [@jrochkind](https://github.com/jrochkind).
 * [#251](https://github.com/intridea/hashie/pull/251): Add block to indifferent access #fetch - [@jgraichen](https://github.com/jgraichen).
+* [#252](https://github.com/intridia/hashie/pull/252): Add support for conditionally required Hashie::Dash attributes - [@ccashwell](https://github.com/ccashwell).
 * Your contribution here.
 
 ## 3.3.2 (11/26/2014)

--- a/README.md
+++ b/README.md
@@ -385,6 +385,8 @@ safe_mash[:zip] = 'test' # => still ArgumentError
 
 Dash is an extended Hash that has a discrete set of defined properties and only those properties may be set on the hash. Additionally, you can set defaults for each property. You can also flag a property as required. Required properties will raise an exception if unset. Another option is message for required properties, which allow you to add custom messages for required property.
 
+You can also conditionally require certain properties by passing a Proc or Symbol. If a Proc is provided, it will be run in the context of the Dash instance. If a Symbol is provided, the value returned for the property or method of the same name will be evaluated. The property will be required if the result of the conditional is truthy.
+
 ### Example:
 
 ```ruby
@@ -392,7 +394,13 @@ class Person < Hashie::Dash
   property :name, required: true
   property :age, required: true, message: 'must be set.'
   property :email
+  property :phone, required: -> { email.nil? }, message: 'is required if email is not set.'
+  property :pants, required: :weekday?, message: 'are only required on weekdays.'
   property :occupation, default: 'Rubyist'
+
+  def weekday?
+    [ Time.now.saturday?, Time.now.sunday? ].none?
+  end
 end
 
 p = Person.new # => ArgumentError: The property 'name' is required for this Dash.

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -425,6 +425,25 @@ describe SubclassedTest do
   end
 end
 
+class ConditionallyRequiredTest < Hashie::Dash
+  property :username
+  property :password, required: -> { !username.nil? }, message: 'must be set, too.'
+end
+
+describe ConditionallyRequiredTest do
+  it 'does not allow a conditionally required property to be set to nil if required' do
+    expect { ConditionallyRequiredTest.new(username: 'bob.smith', password: nil) }.to raise_error(ArgumentError, "The property 'password' must be set, too.")
+  end
+
+  it 'allows a conditionally required property to be set to nil if not required' do
+    expect { ConditionallyRequiredTest.new(username: nil, password: nil) }.not_to raise_error
+  end
+
+  it 'allows a conditionally required property to be set if required' do
+    expect { ConditionallyRequiredTest.new(username: 'bob.smith', password: '$ecure!') }.not_to raise_error
+  end
+end
+
 class MixedPropertiesTest < Hashie::Dash
   property :symbol
   property 'string'


### PR DESCRIPTION
Added support for conditionally required properties on a `Hashie::Dash`. The conditional can be a `Proc` (called within the context of the Dash instance) or `Symbol` (representing a property or method defined by the Dash). The property is required if it evaluates to something truthy.
