### PR TITLE
new extension: Hashie::Extensions::Dash::PsychSerialization

### DIFF
--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -32,6 +32,7 @@ module Hashie
 
     module Dash
       autoload :IndifferentAccess, 'hashie/extensions/dash/indifferent_access'
+      autoload :PsychSerialization, 'hashie/extensions/dash/psych_serialization'
     end
 
     module Mash

--- a/lib/hashie/extensions/dash/psych_serialization.rb
+++ b/lib/hashie/extensions/dash/psych_serialization.rb
@@ -1,0 +1,19 @@
+module Hashie
+  module Extensions
+    module Dash
+      module PsychSerialization
+        def encode_with(coder)
+          self.each { |key, val|
+            coder.map[key] = val
+          }
+        end
+
+        def init_with(coder)
+          coder.map.each {|key, val|
+            self[key] = val
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/hashie/extensions/dash/psych_serialization_spec.rb
+++ b/spec/hashie/extensions/dash/psych_serialization_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'psych'
+
+describe Hashie::Extensions::Dash::PsychSerialization do
+  class DashWithSerialization < Hashie::Dash
+    include Hashie::Extensions::Dash::PsychSerialization
+    property :name, required: true
+    property :child
+  end
+
+  it "serializes and deserializes with Psych" do
+    child = DashWithSerialization.new(name: 'child')
+    instance = DashWithSerialization.new(name: 'dash', child: child)
+
+    instance_yaml = Psych.dump(instance)
+    recovered_instance = Psych.load(instance_yaml)
+
+    expect(recovered_instance).to eq instance
+    expect(recovered_instance.child).to eq child
+  end
+end


### PR DESCRIPTION
Without custom encode_with and init_with methods YAML/Psych serialization will not work. Tested with Ruby 2.1.3
