### PR TITLE
Public utility methods for stringify/symbolize keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#252](https://github.com/intridia/hashie/pull/252): Add support for conditionally required Hashie::Dash attributes - [@ccashwell](https://github.com/ccashwell).
 * [#256](https://github.com/intridia/hashie/pull/256): Inherit key coercions - [@Erol](https://github.com/Erol).
 * [#259](https://github.com/intridia/hashie/pull/259): Fix handling of default proc values in Mash - [@Erol](https://github.com/Erol).
+* [#254](https://github.com/intridea/hashie/pull/254): Public utility methods for stringify/symbolize keys - [@maxlinc](https://github.com/maxlinc).
 * Your contribution here.
 
 ## 3.3.2 (11/26/2014)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ end
 
 The KeyConversion extension gives you the convenience methods of `symbolize_keys` and `stringify_keys` along with their bang counterparts. You can also include just stringify or just symbolize with `Hashie::Extensions::StringifyKeys` or `Hashie::Extensions::SymbolizeKeys`.
 
+Hashie also has a utility method for converting keys on a Hash within including a mixin:
+
+```ruby
+Hashie.symbolize_keys! hash
+# => Symbolizes keys of hash.
+Hashie.symbolize_keys hash
+# => Returns a copy of hash with keys symbolized.
+Hashie.stringify_keys hash
+# => Stringifies keys of hash.
+Hashie.stringify_keys hash
+# => Returns a copy of hash with keys stringified.
+```
+
 ### MergeInitializer
 
 The MergeInitializer extension simply makes it possible to initialize a Hash subclass with another Hash, giving you a quick short-hand.

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -38,4 +38,9 @@ module Hashie
       autoload :SafeAssignment, 'hashie/extensions/mash/safe_assignment'
     end
   end
+
+  class << self
+    include Hashie::Extensions::StringifyKeys::ClassMethods
+    include Hashie::Extensions::SymbolizeKeys::ClassMethods
+  end
 end

--- a/spec/hashie/extensions/symbolize_keys_spec.rb
+++ b/spec/hashie/extensions/symbolize_keys_spec.rb
@@ -1,40 +1,69 @@
 require 'spec_helper'
 require 'support/module_context'
 
+def invoke(method)
+  if subject == object
+    subject.public_send(method)
+  else
+    subject.public_send(method, object)
+  end
+end
+
+shared_examples 'symbolize_keys!' do
+  it 'converts keys to symbols' do
+    object['abc'] = 'abc'
+    object['def'] = 'def'
+    invoke :symbolize_keys!
+    expect((object.keys & [:abc, :def]).size).to eq 2
+  end
+
+  it 'converts nested instances of the same class' do
+    object['ab'] = dummy_class.new
+    object['ab']['cd'] = dummy_class.new
+    object['ab']['cd']['ef'] = 'abcdef'
+    invoke :symbolize_keys!
+    expect(object).to eq(ab: { cd: { ef: 'abcdef' } })
+  end
+
+  it 'converts nested hashes' do
+    object['ab'] = { 'cd' => { 'ef' => 'abcdef' } }
+    invoke :symbolize_keys!
+    expect(object).to eq(ab: { cd: { ef: 'abcdef' } })
+  end
+
+  it 'performs deep conversion within nested arrays' do
+    object['ab'] = []
+    object['ab'] << dummy_class.new
+    object['ab'] << dummy_class.new
+    object['ab'][0]['cd'] = 'abcd'
+    object['ab'][1]['ef'] = 'abef'
+    new_object = invoke :symbolize_keys
+    expect(new_object).to eq(ab: [{ cd: 'abcd' }, { ef: 'abef' }])
+  end
+end
+
+shared_examples 'symbolize_keys' do
+  it 'converts keys to symbols' do
+    object['abc'] = 'def'
+    copy = invoke :symbolize_keys
+    expect(copy[:abc]).to eq 'def'
+  end
+
+  it 'does not alter the original' do
+    object['abc'] = 'def'
+    copy = invoke :symbolize_keys
+    expect(object.keys).to eq ['abc']
+    expect(copy.keys).to eq [:abc]
+  end
+end
+
 describe Hashie::Extensions::SymbolizeKeys do
   include_context 'included hash module'
+  let(:object) { subject }
 
   describe '#symbolize_keys!' do
-    it 'converts keys to symbols' do
-      subject['abc'] = 'abc'
-      subject['def'] = 'def'
-      subject.symbolize_keys!
-      expect((subject.keys & [:abc, :def]).size).to eq 2
-    end
-
-    it 'converts nested instances of the same class' do
-      subject['ab'] = dummy_class.new
-      subject['ab']['cd'] = dummy_class.new
-      subject['ab']['cd']['ef'] = 'abcdef'
-      subject.symbolize_keys!
-      expect(subject).to eq(ab: { cd: { ef: 'abcdef' } })
-    end
-
-    it 'converts nested hashes' do
-      subject['ab'] = { 'cd' => { 'ef' => 'abcdef' } }
-      subject.symbolize_keys!
-      expect(subject).to eq(ab: { cd: { ef: 'abcdef' } })
-    end
-
-    it 'performs deep conversion within nested arrays' do
-      subject['ab'] = []
-      subject['ab'] << dummy_class.new
-      subject['ab'] << dummy_class.new
-      subject['ab'][0]['cd'] = 'abcd'
-      subject['ab'][1]['ef'] = 'abef'
-      subject.symbolize_keys!
-      expect(subject).to eq(ab: [{ cd: 'abcd' }, { ef: 'abef' }])
-    end
+    include_examples 'symbolize_keys!'
+    let(:object) { subject }
 
     it 'returns itself' do
       expect(subject.symbolize_keys!).to eq subject
@@ -42,17 +71,36 @@ describe Hashie::Extensions::SymbolizeKeys do
   end
 
   describe '#symbolize_keys' do
-    it 'converts keys to symbols' do
-      subject['abc'] = 'def'
-      copy = subject.symbolize_keys
-      expect(copy[:abc]).to eq 'def'
-    end
+    include_examples 'symbolize_keys'
+  end
 
-    it 'does not alter the original' do
-      subject['abc'] = 'def'
-      copy = subject.symbolize_keys
-      expect(subject.keys).to eq ['abc']
-      expect(copy.keys).to eq [:abc]
+  context 'class methods' do
+    subject { described_class }
+    let(:object) { Hash.new }
+
+    describe '.symbolize_keys' do
+      include_examples 'symbolize_keys'
     end
+    describe '.symbolize_keys!' do
+      include_examples 'symbolize_keys!'
+    end
+  end
+end
+
+describe Hashie do
+  let!(:dummy_class) do
+    klass = Class.new(::Hash)
+    klass.send :include, Hashie::Extensions::StringifyKeys
+    klass
+  end
+
+  subject { described_class }
+  let(:object) { Hash.new }
+
+  describe '.symbolize_keys' do
+    include_examples 'symbolize_keys'
+  end
+  describe '.symbolize_keys!' do
+    include_examples 'symbolize_keys!'
   end
 end


### PR DESCRIPTION
Sometimes I want to stringify or symbolize a key in a Hash without the need for a subclass, like [Kitchen::Util](https://github.com/test-kitchen/test-kitchen/blob/17ca05a88441e3897f828f39702452d19ba893a5/lib/kitchen/util.rb#L57-L89):

``` ruby
symbolized_hash = Kitchen::Util.symbolized_hash(hash)
stringified_hash = Kitchen::Util.stringified_hash(hash)
```

This was basically implemented already by the `Hashie::Extensions::StringifyKeys` and `Hashie::Extensions::SymbolizeKeys`, but using protected methods that only worked as a mixin and not as a utility method that accepts a hash. This PR changes that so you can stringify/symbolize without including those modules:

``` ruby
symbolized_hash = Hashie::Extensions::SymbolizeKeys.symbolize_keys(hash)
stringified_hash = Hashie::Extensions::StringifyKeys.stringify_keys(hash)
```
