### PR TITLE
Fix bug where Dash changes argument to `property`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#259](https://github.com/intridia/hashie/pull/259): Fixed handling of default proc values in Mash - [@Erol](https://github.com/Erol).
 * [#260](https://github.com/intridia/hashie/pull/260): Added block support to Extensions::DeepMerge - [@galathius](https://github.com/galathius).
 * [#254](https://github.com/intridea/hashie/pull/254): Added public utility methods for stringify and symbolize keys - [@maxlinc](https://github.com/maxlinc).
+* [#261](https://github.com/intridea/hashie/pull/261): Fixed bug where Dash.property modifies argument object - [@d_tw](https://github.com/d_tw).
 * Your contribution here.
 
 ## 3.3.2 (11/26/2014)

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -44,7 +44,7 @@ module Hashie
 
       unless instance_methods.map(&:to_s).include?("#{property_name}=")
         define_method(property_name) { |&block| self.[](property_name, &block) }
-        property_assignment = property_name.to_s.concat('=').to_sym
+        property_assignment = "#{property_name}=".to_sym
         define_method(property_assignment) { |value| self.[]=(property_name, value) }
       end
 

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -486,3 +486,15 @@ describe MixedPropertiesTest do
     expect { subject['symbol'] = 'updated' }.to raise_error(NoMethodError)
   end
 end
+
+context 'Dynamic Dash Class' do
+  it 'define property' do
+    klass       = Class.new(Hashie::Dash)
+    my_property = 'my_property'
+    my_orig     = my_property.dup
+
+    klass.property(my_property)
+
+    expect(my_property).to eq(my_orig)
+  end
+end


### PR DESCRIPTION
Hello,

When calling `Hashie::Dash.property`, where the `property_name` argument is a string, the method modifies the original value of the argument using the `String#concat` method, appending '=' to the string.

```ruby
klass = Class.new(Hashie::Dash)

my_property_name = 'foo' 
# => 'foo'

klass.property(my_property_name)

my_property_name
# => 'foo='
```

I have changed the `Hashie::Dash` code to create a new String object instead of modifying the original.

Thanks!