### PR TITLE
Hashie::Extensions::Persistable

### DIFF
--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -13,6 +13,7 @@ module Hashie
     autoload :DeepMerge,         'hashie/extensions/deep_merge'
     autoload :IgnoreUndeclared,  'hashie/extensions/ignore_undeclared'
     autoload :IndifferentAccess, 'hashie/extensions/indifferent_access'
+    autoload :HashInitializer,  'hashie/extensions/hash_initializer'
     autoload :MergeInitializer,  'hashie/extensions/merge_initializer'
     autoload :MethodAccess,      'hashie/extensions/method_access'
     autoload :MethodQuery,       'hashie/extensions/method_access'
@@ -25,6 +26,7 @@ module Hashie
     autoload :PrettyInspect,     'hashie/extensions/pretty_inspect'
     autoload :KeyConversion,     'hashie/extensions/key_conversion'
     autoload :MethodAccessWithOverride, 'hashie/extensions/method_access'
+    autoload :Persistable,       'hashie/extensions/persistable'
 
     module Parsers
       autoload :YamlErbParser, 'hashie/extensions/parsers/yaml_erb_parser'

--- a/lib/hashie/extensions/hash_initializer.rb
+++ b/lib/hashie/extensions/hash_initializer.rb
@@ -1,0 +1,24 @@
+module Hashie
+  module Extensions
+    # Marker module to indicate has a single-argument hash constructor.
+    module HashInitializer
+    end
+
+    # Doesn't work...
+    # module MergeInitializer
+    # include HashInitializer
+    # end
+  end
+
+  class Hash
+    # Not unless MergeInititalizer is included
+  end
+
+  class Mash
+    include Extensions::HashInitializer
+  end
+
+  class Dash
+    include Extensions::HashInitializer
+  end
+end

--- a/lib/hashie/extensions/persistable.rb
+++ b/lib/hashie/extensions/persistable.rb
@@ -1,0 +1,38 @@
+  module Hashie
+    module Extensions
+      module Persistable
+        CANNOT_INCLUDE = 'Peristable can only be used on classes with Hashie::Extensions::HashInitializer'
+        CANNOT_SAVE = 'Cannot save unless persistable_file is set or the target file is passed as a parameter'
+
+        module ClassMethods
+          def load(file)
+            new(YAML.load(File.read(file))).tap do |h|
+              h.persistable_file = file
+            end
+          end
+        end
+
+        def self.included(base)
+          # Can only include into classes with a hash initializer
+          fail ArgumentError, CANNOT_INCLUDE unless
+            base.include?(Hashie::Extensions::HashInitializer) ||
+            base.include?(Hashie::Extensions::MergeInitializer)
+          base.extend ClassMethods
+          super
+        end
+
+        def save(file = nil)
+          self.persistable_file = file unless file.nil?
+          fail ArgumentError, CANNOT_SAVE if persistable_file.nil?
+          File.write(persistable_file, YAML.dump(self))
+          persistable_file
+        end
+
+        def persistable_file=(file)
+          @persistable_file = Pathname(file)
+        end
+
+        attr_reader :persistable_file
+      end
+    end
+  end

--- a/spec/fixtures/persistable/hello_world.yaml
+++ b/spec/fixtures/persistable/hello_world.yaml
@@ -1,0 +1,3 @@
+---
+foo: bar
+msg: Hello, world!

--- a/spec/hashie/extensions/persistable_spec.rb
+++ b/spec/hashie/extensions/persistable_spec.rb
@@ -1,0 +1,101 @@
+require 'tempfile'
+
+module Hashie
+  module Extensions
+    RSpec.describe Persistable do
+      shared_examples 'loads YAML' do | test_class |
+        describe '.load' do
+          subject(:hash) { test_class.load('spec/fixtures/persistable/hello_world.yaml') }
+          it 'instantiates a instance from a YAML file' do
+            expect(hash).to be_a_kind_of ::Hash
+            expect(hash).to eq(
+              'foo' => 'bar',
+              'msg' => 'Hello, world!'
+            )
+          end
+
+          it 'remembers the filename' do
+            expect(hash.persistable_file).to eq(Pathname('spec/fixtures/persistable/hello_world.yaml'))
+          end
+        end
+      end
+
+      shared_examples 'saves YAML' do | test_class |
+        describe '#save' do
+          let(:obj) do
+            test_class.new(
+              'foo' => 'bar!',
+              'msg' => 'saved!'
+            )
+          end
+
+          it 'raises an error if persistable_file is not set' do
+            expect { obj.save }.to raise_error(ArgumentError, /cannot save unless persistable_file is set/i)
+          end
+
+          it 'saves to persistable_file' do
+            tmpfile = Tempfile.new(['hash', '.yaml'])
+            obj.persistable_file = tmpfile
+            expect(obj.save).to eq(Pathname(tmpfile))
+            expect(test_class.load(tmpfile)).to eq(obj)
+          end
+
+          it 'changes and saves to persistable_file (passed as an argument)' do
+            tmpfile = Tempfile.new(['hash', '.yaml'])
+            expect(obj.save(tmpfile)).to eq(Pathname(tmpfile))
+            expect(obj.persistable_file).to eq(Pathname(tmpfile))
+            expect(test_class.load(tmpfile)).to eq(obj)
+          end
+        end
+
+        describe '#[]=' do
+          context 'with autosave enabled'
+          pending 'autosaves'
+          context 'without autosave enabled' do
+            pending 'does not autosave'
+          end
+        end
+      end
+
+      context 'with Hash' do
+        class MyHash < ::Hash
+          include Hashie::Extensions::MergeInitializer
+          include Hashie::Extensions::Persistable
+        end
+
+        include_examples 'loads YAML', MyHash
+        include_examples 'saves YAML', MyHash
+      end
+
+      context 'with Hashie::Hash' do
+        class MyHashieHash < Hashie::Hash
+          include Hashie::Extensions::MergeInitializer
+          include Hashie::Extensions::Persistable
+        end
+
+        include_examples 'loads YAML', MyHashieHash
+        include_examples 'saves YAML', MyHashieHash
+      end
+
+      context 'with Hashie::Mash' do
+        class MyHashieMash < Hashie::Mash
+          include Hashie::Extensions::Persistable
+        end
+
+        include_examples 'loads YAML', MyHashieMash
+        include_examples 'saves YAML', MyHashieMash
+      end
+
+      context 'with Hashie::Dash' do
+        class MyHashieDash < Hashie::Dash
+          include Hashie::Extensions::Persistable
+          property 'foo'
+          property 'msg'
+        end
+
+        include_examples 'loads YAML', MyHashieDash
+        include_examples 'saves YAML', MyHashieDash
+      end
+    end
+  end
+end


### PR DESCRIPTION
I didn't see #185 until just now, so this might be a duplicate of that, although this takes a fairly different approach (extension vs class). But that's why I'm opening this PR now to get some early feedback, rather than implementing the other features on my mind (autoload/autosave).

Hashie already has `Hashie::Mash#load`, but it doesn't have `Hashie::Mash#save`, and there's also no way to load or save a Dash or other Hashie classes. This adds a Persistable mixin so any hash-like class can be loaded (if it has a compatible initializer) or saved.

Usage:

```ruby
class MyHash < ::Hash
  include Hashie::Extensions::MergeInitializer
  include Hashie::Extensions::Persistable
end

hash1 = MyHash.load('my_data.yaml')
hash1['foo'] #=> 'bar'
hash1['magic_number'] = 42
hash1.save # still remembers 'my_data.yaml'

hash2 = MyHash.new({
  'foo' => 'bar',
  'favorite_color' => 'red'
})
hash2.save # raises exception - don't know where to save to...
                   # or it could save to a tempfile and return the path...
hash2.save('other_data.yaml') # now it works
```

I had planned on implementing autosave, but I want some feedback before going any further.

Also, right now it's only persisting YAML, but I think it wouldn't be hard to modify to support JSON and "YamlErb" (which is what's currently used by Hashie::Mash). You just need to swap out the adapter class and/or options... in theory you could even use Moneta, though I think the fact that Moneta doesn't support `#keys`, `#each` or `#to_hash` would be problematic.

Any thoughts before I go further down this path?