### PR TITLE
provide self as context when evaluating default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* [#271](https://github.com/intridea/hashie/pull/271): Added ability to define defaults based on current hash - [@gregory](https://github.com/gregory).
 * [#247](https://github.com/intridea/hashie/pull/247): Fixed #stringify_keys and #symbolize_keys collision with ActiveSupport - [@bartoszkopinski](https://github.com/bartoszkopinski).
 * [#249](https://github.com/intridea/hashie/pull/249): SafeAssignment will now also protect hash-style assignments - [@jrochkind](https://github.com/jrochkind).
 * [#251](https://github.com/intridea/hashie/pull/251): Added block support to indifferent access #fetch - [@jgraichen](https://github.com/jgraichen).

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -96,7 +96,8 @@ module Hashie
 
       self.class.defaults.each_pair do |prop, value|
         self[prop] = begin
-          value.dup
+          val = value.dup
+          val.is_a?(Proc) && val.arity > 0 ? val.call(self) : val
         rescue TypeError
           value
         end

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -46,6 +46,11 @@ class DeferredTest < Hashie::Dash
   property :created_at, default: proc { Time.now }
 end
 
+class DeferredWithSelfTest < Hashie::Dash
+  property :created_at, default: -> { Time.now }
+  property :updated_at, default: ->(test) { test.created_at }
+end
+
 describe DashTest do
   def property_required_error(property)
     [ArgumentError, "The property '#{property}' is required for #{subject.class.name}."]
@@ -165,6 +170,14 @@ describe DashTest do
     it 'does not evalute proc after subsequent reads' do
       deferred = DeferredTest.new
       expect(deferred[:created_at].object_id).to eq deferred[:created_at].object_id
+    end
+  end
+
+  context 'reading from a deferred property based on context' do
+    it 'provides the current hash as context for evaluation' do
+      deferred = DeferredWithSelfTest.new
+      expect(deferred[:created_at].object_id).to eq deferred[:created_at].object_id
+      expect(deferred[:updated_at].object_id).to eq deferred[:created_at].object_id
     end
   end
 


### PR DESCRIPTION
Ability to define defaults based on the current hash. Pretty straight forward.