### PR TITLE
Remove mention of Hashie::Extensions::DeepLocate for 3.4.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Release
 
+* [#269](https://github.com/intridea/hashie/pull/272): Added Hashie::Extensions::DeepLocate - [@msievers](https://github.com/msievers).
 * Your contribution here
 
 ## 3.4.0 (02/02/2014)
@@ -16,8 +17,6 @@
 * [#261](https://github.com/intridea/hashie/pull/261): Fixed bug where Dash.property modifies argument object - [@d_tw](https://github.com/d_tw).
 * [#264](https://github.com/intridea/hashie/pull/264): Methods such as abc? return true/false with Hashie::Extensions::MethodReader - [@Zloy](https://github.com/Zloy).
 * [#269](https://github.com/intridea/hashie/pull/269): Add #extractable_options? so ActiveSupport Array#extract_options! can extract it - [@ridiculous](https://github.com/ridiculous).
-* [#269](https://github.com/intridea/hashie/pull/272): Added Hashie::Extensions::DeepLocate - [@msievers](https://github.com/msievers).
-* Your contribution here.
 
 ## 3.3.2 (11/26/2014)
 


### PR DESCRIPTION
The CHANGELOG mistakenly mentions ```Hashie::Extensions::DeepLocate``` for ```3.4.0```, but it was merged after the last release, so it should be ```Next Release```.