### PR TITLE
Fix crash building a Mash w/ IndifferentAccess from HashWithIndifferentAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next Release
 
 * [#269](https://github.com/intridea/hashie/pull/272): Added Hashie::Extensions::DeepLocate - [@msievers](https://github.com/msievers).
+* [#270](https://github.com/intridea/hashie/pull/277): Fixed ArgumentError raised when using IndifferentAccess and HashWithIndifferentAccess - [@gardenofwine](https://github.com/gardenofwine).
 * Your contribution here
 
 ## 3.4.0 (02/02/2014)

--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -76,16 +76,16 @@ module Hashie
       # is injecting itself into member hashes.
       def convert!
         keys.each do |k|
-          regular_writer convert_key(k), convert_value(regular_delete(k))
+          regular_writer convert_key(k), indifferent_value(regular_delete(k))
         end
         self
       end
 
-      def convert_value(value)
+      def indifferent_value(value)
         if hash_lacking_indifference?(value)
           IndifferentAccess.inject!(value)
         elsif value.is_a?(::Array)
-          value.replace(value.map { |e| convert_value(e) })
+          value.replace(value.map { |e| indifferent_value(e) })
         else
           value
         end
@@ -104,7 +104,7 @@ module Hashie
       end
 
       def indifferent_writer(key, value)
-        regular_writer convert_key(key), convert_value(value)
+        regular_writer convert_key(key), indifferent_value(value)
       end
 
       def indifferent_fetch(key, *args, &block)

--- a/spec/hashie/extensions/indifferent_access_with_rails_hwia_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_with_rails_hwia_spec.rb
@@ -1,8 +1,9 @@
 # This set of tests verifies that Hashie::Extensions::IndifferentAccess works with
 # ActiveSupport HashWithIndifferentAccess hashes. See #164 and #166 for details.
 
-require 'spec_helper'
 require 'active_support/hash_with_indifferent_access'
+require 'active_support/core_ext/hash'
+require 'spec_helper'
 
 describe Hashie::Extensions::IndifferentAccess do
   class IndifferentHashWithMergeInitializer < Hash
@@ -33,6 +34,10 @@ describe Hashie::Extensions::IndifferentAccess do
   class CoercableHash < Hash
     include Hashie::Extensions::Coercion
     include Hashie::Extensions::MergeInitializer
+  end
+
+  class MashWithIndifferentAccess < Hashie::Mash
+    include Hashie::Extensions::IndifferentAccess
   end
 
   shared_examples_for 'hash with indifferent access' do
@@ -191,6 +196,13 @@ describe Hashie::Extensions::IndifferentAccess do
       expect(instance[:foo].keys).to all(be_coerced)
       expect(instance[:foo].values).to all(be_coerced)
       expect(instance[:foo]).to be_a(ActiveSupport::HashWithIndifferentAccess)
+    end
+  end
+
+  describe 'Mash with indifferent access' do
+    it 'is able to be created for a deep nested HashWithIndifferentAccess' do
+      indifferent_hash = ActiveSupport::HashWithIndifferentAccess.new(abc: { def: 123 })
+      MashWithIndifferentAccess.new(indifferent_hash)
     end
   end
 end


### PR DESCRIPTION
When using an ActiveRecord::HashWithIndifferentAccess that is nested (i.e. {a: {b: 1}}) to create a Mash with the IndifferentAccess extension, an ArgumentException is raised. This is because the IndifferentAccess method `convert_value` overrides ActiveRecord::HashWithIndifferentAccess's method of the same name. Changing the method name in IndifferentAccess solves the issue.