### PR TITLE
Add and test Hashie::Mash#reverse_merge

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 170
+  Max: 172
 
 # Offense count: 8
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#269](https://github.com/intridea/hashie/pull/272): Added Hashie::Extensions::DeepLocate - [@msievers](https://github.com/msievers).
 * [#270](https://github.com/intridea/hashie/pull/277): Fixed ArgumentError raised when using IndifferentAccess and HashWithIndifferentAccess - [@gardenofwine](https://github.com/gardenofwine).
+* [#281](https://github.com/intridea/hashie/pull/281): Added #reverse_merge to Mash to override ActiveSupport's version - [@mgold](https://github.com/mgold).
 * Your contribution here
 
 ## 3.4.0 (02/02/2014)

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -255,6 +255,11 @@ module Hashie
       true
     end
 
+    # another ActiveSupport method, see issue #270
+    def reverse_merge(other_hash)
+      Hashie::Mash.new(other_hash).merge(self)
+    end
+
     protected
 
     def method_suffix(method_name)

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -651,4 +651,17 @@ describe Hashie::Mash do
       expect(args).to eq [101, 'bar']
     end
   end
+
+  describe '#reverse_merge' do
+    subject { described_class.new(a: 1, b: 2) }
+
+    it 'unifies strings and symbols' do
+      expect(subject.reverse_merge(a: 2).length).to eq 2
+      expect(subject.reverse_merge('a' => 2).length).to eq 2
+    end
+
+    it 'does not overwrite values' do
+      expect(subject.reverse_merge(a: 5).a).to eq subject.a
+    end
+  end
 end


### PR DESCRIPTION
Fixes #270. I had to bump Rubocop's max class length. If that's a problem, some refactoring will be necessary.

This will define `reverse_merge` even when ActiveSupport is not included. One solution is to wrap the definition with `if method_defined? :reverse_merge`.