### PR TITLE
Coercion scope bug

### DIFF
--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -178,7 +178,7 @@ module Hashie
         def inherited(klass)
           super
 
-          klass.key_coercions = key_coercions
+          klass.key_coercions = key_coercions.dup
         end
       end
     end

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -47,8 +47,13 @@ describe Hashie::Extensions::Coercion do
         coerce_key :bar, Integer
       end
 
+      class OtherNestedCoercableHash < BaseCoercableHash
+        coerce_key :foo, Symbol
+      end
+
       class RootCoercableHash < BaseCoercableHash
         coerce_key :nested, NestedCoercableHash
+        coerce_key :other, OtherNestedCoercableHash
         coerce_key :nested_list, Array[NestedCoercableHash]
         coerce_key :nested_hash, Hash[String => NestedCoercableHash]
       end
@@ -61,6 +66,13 @@ describe Hashie::Extensions::Coercion do
 
       subject { RootCoercableHash }
       let(:instance) { subject.new }
+
+      it 'does not add coercions to superclass' do
+        instance[:nested] = { foo: 'bar' }
+        instance[:other]  = { foo: 'bar' }
+        expect(instance[:nested][:foo]).to be_a String
+        expect(instance[:other][:foo]).to be_a Symbol
+      end
 
       it 'coerces nested objects' do
         instance[:nested] = { foo: 123, bar: '456' }


### PR DESCRIPTION
Found a nasty bug.

The coercions are being stored on the superclass rather than the current class. This means that two classes that share the same superclass can't have conflicting coercions. This PR has I test, I don't have a fix yet.

I can't even mark the test as pending. Just defining `OtherNestedCoercableHash` breaks `NestedCoercableHash` even if it's never used. The problem is that it defines the coercion on `RootCoercableHash` so the definition from one class leaks into the scope of the other. Since the type was different that breaks other specs.