### PR TITLE
Opt in to containerized Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 
 rvm:
   - 2.1.2


### PR DESCRIPTION
Travis released [Docker-based build containers][blog] in December that
should speed up test time. I just had to wait over half an hour for
a build to finish, so I thought we could try this out. I think we're
a pretty ideal candidate because:

1. we don't need sudo for anything; and
2. we aren't an I/O-bound test suite

[blog]: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/