### PR TITLE
Create spec to demonstrate that superclasses are not affected by coercions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Next Release
-
+* [#282](https://github.com/intridea/hashie/pull/282): Fixed a bug that caused coercions in a subclass to be added to the superclass - [@maxlinc](https://github.com/maxlinc) [@martinstreicher](https://github.com/martinstreicher).
 * [#269](https://github.com/intridea/hashie/pull/272): Added Hashie::Extensions::DeepLocate - [@msievers](https://github.com/msievers).
 * [#270](https://github.com/intridea/hashie/pull/277): Fixed ArgumentError raised when using IndifferentAccess and HashWithIndifferentAccess - [@gardenofwine](https://github.com/gardenofwine).
 * [#281](https://github.com/intridea/hashie/pull/281): Added #reverse_merge to Mash to override ActiveSupport's version - [@mgold](https://github.com/mgold).

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -178,7 +178,7 @@ module Hashie
         def inherited(klass)
           super
 
-          klass.key_coercions = key_coercions
+          klass.key_coercions = key_coercions.dup
         end
       end
     end

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -406,17 +406,23 @@ describe Hashie::Extensions::Coercion do
     end
 
     context 'when subclassing' do
-      class MyHash < Hash
+      class MyOwnBase < Hash
         include Hashie::Extensions::Coercion
+      end
 
+      class MyOwnHash < MyOwnBase
         coerce_key :value, Integer
       end
 
-      class MySubclass < MyHash
+      class MyOwnSubclass < MyOwnHash
       end
 
       it 'inherits key coercions' do
-        expect(MyHash.key_coercions).to eql(MySubclass.key_coercions)
+        expect(MyOwnHash.key_coercions).to eql(MyOwnSubclass.key_coercions)
+      end
+
+      it 'the superclass does not accumulate coerced attributes from subclasses' do
+        expect(MyOwnBase.key_coercions).to eq({})
       end
     end
   end


### PR DESCRIPTION
This is an additional spec to show that the fix at https://github.com/intridea/hashie/pull/282 works. This spec is perhaps a little more readable, in the sense that it shows a typical case where the bug occurs. This spec reflects what was occurring in my code almost exactly. 
