### PR TITLE
remove unneeded id and type cover methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* [#292](https://github.com/intridea/hashie/pull/292): Remove unneeded Mash#id and #type cover methods - [@jrochkind](https://github.com/jrochkind)
+
 * Your contribution here
 
 ## 3.4.1 (3/31/2015)

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -92,14 +92,6 @@ module Hashie
 
     class << self; alias_method :[], :new; end
 
-    def id #:nodoc:
-      self['id']
-    end
-
-    def type #:nodoc:
-      self['type']
-    end
-
     alias_method :regular_reader, :[]
     alias_method :regular_writer, :[]=
 


### PR DESCRIPTION
Ruby 1.8.7 had Object#id and #type, both of which were deprecated,
which Hashie::Mash wanted to cover with more reasonable methods.
These methods in Object were removed in ruby 1.9.  The cover methods
are unneeded, and can cause problems with Mash::SafeAssignment
preventing you from using these as keys.

Fixes #290