### PR TITLE
Fixed specs to run with Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: 2.2.1 # https://github.com/intridea/hashie/pull/285

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -346,15 +346,25 @@ describe Hashie::Mash do
     it 'responds to a set key with a suffix' do
       %w(= ? ! _).each do |suffix|
         expect(subject).to be_respond_to(:"abc#{suffix}")
-        expect(subject.method(:"abc#{suffix}")).to_not be_nil
       end
+
+      # it seems for ruby 2.2 :"abc#{suffix}" !== :"abc#{'='}" internally
+      expect(subject.method(:"abc#{'='}")).to_not be_nil
+      expect(subject.method(:"abc#{'?'}")).to_not be_nil
+      expect(subject.method(:"abc#{'!'}")).to_not be_nil
+      expect(subject.method(:"abc#{'_'}")).to_not be_nil
     end
 
     it 'responds to an unknown key with a suffix' do
       %w(= ? ! _).each do |suffix|
         expect(subject).to be_respond_to(:"xyz#{suffix}")
-        expect(subject.method(:"xyz#{suffix}")).to_not be_nil
       end
+
+      # it seems for ruby 2.2 :"abc#{suffix}" !== :"abc#{'='}" internally
+      expect(subject.method(:"xyz#{'='}")).to_not be_nil
+      expect(subject.method(:"xyz#{'?'}")).to_not be_nil
+      expect(subject.method(:"xyz#{'!'}")).to_not be_nil
+      expect(subject.method(:"xyz#{'_'}")).to_not be_nil
     end
 
     it 'does not respond to an unknown key without a suffix' do

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -348,7 +348,7 @@ describe Hashie::Mash do
         expect(subject).to be_respond_to(:"abc#{suffix}")
       end
 
-      # it seems for ruby 2.2 :"abc#{suffix}" !== :"abc#{'='}" internally
+      # for ruby 2.2 - https://github.com/intridea/hashie/pull/285
       expect(subject.method(:"abc#{'='}")).to_not be_nil
       expect(subject.method(:"abc#{'?'}")).to_not be_nil
       expect(subject.method(:"abc#{'!'}")).to_not be_nil
@@ -360,7 +360,7 @@ describe Hashie::Mash do
         expect(subject).to be_respond_to(:"xyz#{suffix}")
       end
 
-      # it seems for ruby 2.2 :"abc#{suffix}" !== :"abc#{'='}" internally
+      # for ruby 2.2 - https://github.com/intridea/hashie/pull/285
       expect(subject.method(:"xyz#{'='}")).to_not be_nil
       expect(subject.method(:"xyz#{'?'}")).to_not be_nil
       expect(subject.method(:"xyz#{'!'}")).to_not be_nil


### PR DESCRIPTION
This is a rebased version of the fix by @msievers that makes all of the specs run on Ruby 2.2. I removed 2.2.1 from allowed failures and fixed the merge conflict.

The fix works around an issue in Ruby 2.2 with retrieving methods from `respond_to_missing`.

Original PR: #273 
Ruby language bug tracking: #285 
Reason for adding: #291 