### PR TITLE
Retain Mash's original key with indifferent access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 172
+  Max: 178
 
 # Offense count: 8
 Metrics/CyclomaticComplexity:

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -181,6 +181,18 @@ describe DashTest do
     end
   end
 
+  context 'converting from a Mash' do
+    class ConvertingFromMash < Hashie::Dash
+      property :property, required: true
+    end
+
+    let(:mash) { Hashie::Mash.new(property: 'test') }
+
+    it 'works without considering key storage' do
+      expect { ConvertingFromMash.new(mash) }.not_to raise_error
+    end
+  end
+
   describe '#new' do
     it 'fails with non-existent properties' do
       expect { described_class.new(bork: '') }.to raise_error(*no_property_error('bork'))

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -243,7 +243,7 @@ describe Hashie::Mash do
       end
 
       it 'leaves only specified keys' do
-        expect(subject.keys.sort).to eq %i(details middle_name)
+        expect(subject.keys.sort).to eq [:details, :middle_name]
         expect(subject.first_name?).to be_falsy
         expect(subject).not_to respond_to(:first_name)
         expect(subject.last_name?).to be_falsy

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -106,9 +106,9 @@ describe Hashie::Mash do
 
   it 'allows for multi-level assignment through bang methods' do
     subject.author!.name = 'Michael Bleigh'
-    expect(subject.author).to eq Hashie::Mash.new(name: 'Michael Bleigh')
+    expect(subject.author).to eq Hashie::Mash.new('name' => 'Michael Bleigh')
     subject.author!.website!.url = 'http://www.mbleigh.com/'
-    expect(subject.author.website).to eq Hashie::Mash.new(url: 'http://www.mbleigh.com/')
+    expect(subject.author.website).to eq Hashie::Mash.new('url' => 'http://www.mbleigh.com/')
   end
 
   it 'allows for multi-level under bang testing' do
@@ -231,7 +231,7 @@ describe Hashie::Mash do
       end
 
       it 'returns self' do
-        expect(subject.replace(foo: 'bar').to_hash).to eq('foo' => 'bar')
+        expect(subject.replace(foo: 'bar').to_hash).to eq(foo: 'bar')
       end
 
       it 'sets all specified keys to their corresponding values' do
@@ -243,7 +243,7 @@ describe Hashie::Mash do
       end
 
       it 'leaves only specified keys' do
-        expect(subject.keys.sort).to eq %w(details middle_name)
+        expect(subject.keys.sort).to eq %i(details middle_name)
         expect(subject.first_name?).to be_falsy
         expect(subject).not_to respond_to(:first_name)
         expect(subject.last_name?).to be_falsy


### PR DESCRIPTION
This is an attempt at fixing the issue of Mash's keys being converted
to strings upon assignment. Since we want Mash to behave like a Hash,
this is undesireable; however, many gems downstream depend on the
indifferent access that is achieved through casting all keys to strings.

I had to touch a few tests that were looking specifically for a certain
type of key (i.e. relying on the fact that keys are cast). They should
now be semantically correct.

There is one interesting thing that pops out from this. Checking for
equality between Mashes (and Hashes with Mashes) now fails unless the
keys are equivalent. For example:

``` ruby
Hashie::Mash.new(p: 'test') == Hashie::Mash.new('p' => 'test') #=> false
```

I also added a test for issue #246, which is solved by this PR.

I _believe_ that this should perform on par with the current
implementation. I'm going to work on a benchmark to double-check, since
a performance regression is less desireable than the fix that this
gives.

Fixes #196
Fixes #246
