### PR TITLE
Speed up SafeAssignment and fix private methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Your contribution here.
 * [#304](https://github.com/intridea/hashie/pull/304): Ensured compatibility of `Hash` extensions with singleton objects - [@regexident](https://github.com/regexident).
-* [#306](https://github.com/intridea/hashie/pull/306): Added Hashie::Extensions::Dash::Coercion - [@marshall-lee](https://github.com/marshall-lee).
+* [#306](https://github.com/intridea/hashie/pull/306): Added `Hashie::Extensions::Dash::Coercion` - [@marshall-lee](https://github.com/marshall-lee).
+* [#310](https://github.com/intridea/hashie/pull/310): Fixed `Hashie::Extensions::SafeAssignment` bug with private methods - [@marshall-lee](https://github.com/marshall-lee).
 
 ## 3.4.2 (6/2/2015)
 

--- a/lib/hashie/extensions/mash/safe_assignment.rb
+++ b/lib/hashie/extensions/mash/safe_assignment.rb
@@ -3,7 +3,7 @@ module Hashie
     module Mash
       module SafeAssignment
         def custom_writer(key, *args) #:nodoc:
-          fail ArgumentError, "The property #{key} clashes with an existing method." if methods.include?(key.to_sym)
+          fail ArgumentError, "The property #{key} clashes with an existing method." if !key?(key) && respond_to?(key, true)
           super
         end
 

--- a/spec/hashie/extensions/mash/safe_assignment_spec.rb
+++ b/spec/hashie/extensions/mash/safe_assignment_spec.rb
@@ -3,14 +3,41 @@ require 'spec_helper'
 describe Hashie::Extensions::Mash::SafeAssignment do
   class MashWithSafeAssignment < Hashie::Mash
     include Hashie::Extensions::Mash::SafeAssignment
+
+    private
+
+    def my_own_private
+      :hello!
+    end
   end
 
   context 'when included in Mash' do
     subject { MashWithSafeAssignment.new }
 
+    context 'when not attempting to override a method' do
+      it 'assigns just fine' do
+        expect do
+          subject.blabla = 'Test'
+          subject.blabla = 'Test'
+        end.to_not raise_error
+      end
+    end
+
     context 'when attempting to override a method' do
       it 'raises an error' do
         expect { subject.zip = 'Test' }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when attempting to override a private method' do
+      it 'raises an error' do
+        expect { subject.my_own_private = 'Test' }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when attempting to initialize with predefined method' do
+      it 'raises an error' do
+        expect { MashWithSafeAssignment.new(zip: true) }.to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
`Hashie::Extensions::Mash::SafeAssignment` is in trouble!

1. No one should use `methods.include?`, it is **very** slow!
2. There's a trouble with private methods because `methods` doesn't return them.
3. Specs are weak.