### PR TITLE
Default bin scripts from bundle gem command: bin/console and bin/setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#306](https://github.com/intridea/hashie/pull/306): Added `Hashie::Extensions::Dash::Coercion` - [@marshall-lee](https://github.com/marshall-lee).
 * [#310](https://github.com/intridea/hashie/pull/310): Fixed `Hashie::Extensions::SafeAssignment` bug with private methods - [@marshall-lee](https://github.com/marshall-lee).
 * [#313](https://github.com/intridea/hashie/pull/313): Restrict pending spec to only Ruby versions 2.2.0-2.2.2 - [@pboling](https://github.com/pboling).
+* [#315](https://github.com/intridea/hashie/pull/315): Default `bin/` scripts: `console` and `setup` - [@pboling](https://github.com/pboling).
 
 ## 3.4.2 (6/2/2015)
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "hashie"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here


### PR DESCRIPTION
- [x] `bin/console`
- [x] `bin/setup`

A comparison between the current `irb` use case, and the new `bin/console` use case:
Old and janky:
```
∴ irb
>> require "bundler/setup"
=> true
>> require "hashie"
=> true
>> Hashie::Mash.new(hi: "@dblock")
=> #<Hashie::Mash hi="@dblock">
```
New hotness:
```
∴ bin/console
>> Hashie::Mash.new(hi: "@dblock")
=> #<Hashie::Mash hi="@dblock">
```