### PR TITLE
Ruby 2.2.3 is out and fixes a bug with Hashie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.2.2
-  - 2.1.6
+  - 2.2.3
+  - 2.1.7
   - 2.0.0
   - 1.9.3
-  - jruby-19mode
+  - rbx-2.5.8
   - rbx-2.2.10
+  - jruby-19mode
   - jruby-head
   - ruby-head
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your contribution here.
 * [#304](https://github.com/intridea/hashie/pull/304): Ensured compatibility of `Hash` extensions with singleton objects - [@regexident](https://github.com/regexident).
+* [#316](https://github.com/intridea/hashie/pull/316): Update Travis Build Matrix (ruby-2.2.3, rbx-2.5.8) - [@pboling](https://github.com/pboling).
 * [#306](https://github.com/intridea/hashie/pull/306): Added `Hashie::Extensions::Dash::Coercion` - [@marshall-lee](https://github.com/marshall-lee).
 * [#310](https://github.com/intridea/hashie/pull/310): Fixed `Hashie::Extensions::SafeAssignment` bug with private methods - [@marshall-lee](https://github.com/marshall-lee).
 * [#313](https://github.com/intridea/hashie/pull/313): Restrict pending spec to only Ruby versions 2.2.0-2.2.2 - [@pboling](https://github.com/pboling).

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -350,6 +350,8 @@ describe Hashie::Mash do
     end
 
     it 'is able to access the suffixed key as a method' do
+      # When run as an individual file on Ruby 2.0.0 this spec fails on :abc?,
+      # But when run as a suite it passes.  Very Strange.
       %w(= ? ! _).each do |suffix|
         expect(subject.method(:"abc#{suffix}")).to_not be_nil
       end


### PR DESCRIPTION
Travis Build Matrix updates:
- [x] Update Ruby 2.2.x from 2.2.2 to 2.2.3
- [x] Update Ruby 2.1.x from 2.1.6 to 2.1.7
- [x] Add Latest Rubinius \*\*
  - as rbx-2.5.8
  - but keep existing 2.2.10

\*\* Rubinius has had [MANY releases](http://rubini.us/downloads/) since 2.2.10.  Current is 2.5.8.