### PR TITLE
Removed `Hashie::Extensions::MergeInitializer` from `StrictKeyAccess` Extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,11 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-task default: [:rubocop, :spec]
+require 'ruby_engine'
+if RubyEngine.is? 'rbx'
+  # Rubinius 2.5.8 crashes Rubocop:
+  # https://github.com/rubinius/rubinius/issues/3485
+  task default: [:spec]
+else
+  task default: [:rubocop, :spec]
+end

--- a/lib/hashie/extensions/strict_key_access.rb
+++ b/lib/hashie/extensions/strict_key_access.rb
@@ -15,7 +15,7 @@ module Hashie
     #     >> hash[:cow]
     #       KeyError: key not found: :cow
     #
-    # NOTE: For googlers coming from Python to Ruby, this extension makes a Hash behave like a "Dictionary".
+    # NOTE: For googlers coming from Python to Ruby, this extension makes a Hash behave more like a "Dictionary".
     #
     module StrictKeyAccess
       class DefaultError < StandardError
@@ -24,20 +24,23 @@ module Hashie
         end
       end
 
-      # NOTE: This extension would break the default behavior of Hash initialization:
+      # NOTE: Defaults don't make any sense with a StrictKeyAccess.
+      # NOTE: When key lookup fails a KeyError is raised.
       #
-      #     >> a = StrictKeyAccessHash.new(a: :b)
+      # Normal:
+      #
+      #     >> a = Hash.new(123)
       #     => {}
-      #     >> a[:a]
-      #       KeyError: key not found: :a
+      #     >> a["noes"]
+      #     => 123
       #
-      # Includes the Hashie::Extensions::MergeInitializer extension to get around that problem.
-      # Also note that defaults still don't make any sense with a StrictKeyAccess.
-      def self.included(base)
-        # Can only include into classes with a hash initializer
-        base.send(:include, Hashie::Extensions::MergeInitializer)
-      end
-
+      # With StrictKeyAccess:
+      #
+      #     >> a = StrictKeyAccessHash.new(123)
+      #     => {}
+      #     >> a["noes"]
+      #       KeyError: key not found: "noes"
+      #
       def [](key)
         fetch(key)
       end


### PR DESCRIPTION
- [x] Removed `Hashie::Extensions::MergeInitializer` from `StrictKeyAccess` Extension
- [x] Updated, and enhanced specs
- [x] Improved documentation
- [x] [Rubinius 2.5.8 Crashes Rubocop](https://github.com/rubinius/rubinius/issues/3485#issuecomment-150709760) (which is the current release, but only sometimes - unsure as to reason), so disabling Rubocop when running in Rubinius