### PR TITLE
Make DeepLocate indifference-aware by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.4.4 (Next)
 
 * [#317](https://github.com/intridea/hashie/pull/317): Ensure `Hashie::Extensions::MethodQuery` methods return boolean values - [@michaelherold](https://github.com/michaelherold).
+* [#319](https://github.com/intridea/hashie/pull/319): Fix a regression from 3.4.1 where `Hashie::Extensions::DeepFind` is no longer indifference-aware - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## 3.4.3 (10/25/2015)

--- a/spec/hashie/extensions/deep_find_spec.rb
+++ b/spec/hashie/extensions/deep_find_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support/core_ext/hash/indifferent_access'
 
 describe Hashie::Extensions::DeepFind do
   subject { Class.new(Hash) { include Hashie::Extensions::DeepFind } }
@@ -40,6 +41,73 @@ describe Hashie::Extensions::DeepFind do
 
     it 'returns nil if it does not find any matches' do
       expect(instance.deep_find_all(:wahoo)).to be_nil
+    end
+  end
+
+  context 'on an ActiveSupport::HashWithIndifferentAccess' do
+    subject(:instance) { hash.with_indifferent_access.extend(Hashie::Extensions::DeepFind) }
+
+    describe '#deep_find' do
+      it 'indifferently detects a value from a nested hash' do
+        expect(instance.deep_find(:address)).to eq('123 Library St.')
+        expect(instance.deep_find('address')).to eq('123 Library St.')
+      end
+
+      it 'indifferently detects a value from a nested array' do
+        expect(instance.deep_find(:title)).to eq('Call of the Wild')
+        expect(instance.deep_find('title')).to eq('Call of the Wild')
+      end
+
+      it 'indifferently returns nil if it does not find a match' do
+        expect(instance.deep_find(:wahoo)).to be_nil
+        expect(instance.deep_find('wahoo')).to be_nil
+      end
+    end
+
+    describe '#deep_find_all' do
+      it 'indifferently detects all values from a nested hash' do
+        expect(instance.deep_find_all(:title)).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+        expect(instance.deep_find_all('title')).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+      end
+
+      it 'indifferently returns nil if it does not find any matches' do
+        expect(instance.deep_find_all(:wahoo)).to be_nil
+        expect(instance.deep_find_all('wahoo')).to be_nil
+      end
+    end
+  end
+
+  context 'on a Hash including Hashie::Extensions::IndifferentAccess' do
+    let(:klass) { Class.new(Hash) { include Hashie::Extensions::IndifferentAccess } }
+    subject(:instance) { klass[hash.dup].extend(Hashie::Extensions::DeepFind) }
+
+    describe '#deep_find' do
+      it 'indifferently detects a value from a nested hash' do
+        expect(instance.deep_find(:address)).to eq('123 Library St.')
+        expect(instance.deep_find('address')).to eq('123 Library St.')
+      end
+
+      it 'indifferently detects a value from a nested array' do
+        expect(instance.deep_find(:title)).to eq('Call of the Wild')
+        expect(instance.deep_find('title')).to eq('Call of the Wild')
+      end
+
+      it 'indifferently returns nil if it does not find a match' do
+        expect(instance.deep_find(:wahoo)).to be_nil
+        expect(instance.deep_find('wahoo')).to be_nil
+      end
+    end
+
+    describe '#deep_find_all' do
+      it 'indifferently detects all values from a nested hash' do
+        expect(instance.deep_find_all(:title)).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+        expect(instance.deep_find_all('title')).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+      end
+
+      it 'indifferently returns nil if it does not find any matches' do
+        expect(instance.deep_find_all(:wahoo)).to be_nil
+        expect(instance.deep_find_all('wahoo')).to be_nil
+      end
     end
   end
 end

--- a/spec/hashie/extensions/deep_locate_spec.rb
+++ b/spec/hashie/extensions/deep_locate_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support/core_ext/hash/indifferent_access'
 
 describe Hashie::Extensions::DeepLocate do
   let(:hash) do
@@ -119,6 +120,18 @@ describe Hashie::Extensions::DeepLocate do
 
     it 'adds #deep_locate' do
       expect(instance.deep_locate(:bool)).to eq([hash[:query]])
+    end
+  end
+
+  context 'on an ActiveSupport::HashWithIndifferentAccess' do
+    let(:instance) { hash.dup.with_indifferent_access }
+
+    it 'can locate symbolic keys' do
+      expect(described_class.deep_locate(:lsr10, instance)).to eq ['lsr10' => { 'gte' => 2014 }]
+    end
+
+    it 'can locate string keys' do
+      expect(described_class.deep_locate('lsr10', instance)).to eq ['lsr10' => { 'gte' => 2014 }]
     end
   end
 end


### PR DESCRIPTION
`Hashie::Extensions::DeepLocate.deep_locate`, when passed a key, did not
take into account indifferent access. This lead to a regression in
v3.4.1 when `Hashie::Extensions::DeepFind` was modified to be backed by
`DeepLocate`.

This change makes the default comparator aware of indifferent access by
inspecting the object that it is called on. It works with both
`ActiveSupport::HashWithIndifferentAccess` and
`Hashie::Extensions::IndifferentAccess`.

Fixes #309