### PR TITLE
Clash: multiple bang notation calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#317](https://github.com/intridea/hashie/pull/317): Ensure `Hashie::Extensions::MethodQuery` methods return boolean values - [@michaelherold](https://github.com/michaelherold).
 * [#319](https://github.com/intridea/hashie/pull/319): Fix a regression from 3.4.1 where `Hashie::Extensions::DeepFind` is no longer indifference-aware - [@michaelherold](https://github.com/michaelherold).
+* [#240](https://github.com/intridea/hashie/pull/240): Fixed nesting twice with Clash keys - [@bartoszkopinski](https://github.com/bartoszkopinski).
 * Your contribution here.
 
 ## 3.4.3 (10/25/2015)

--- a/spec/hashie/clash_spec.rb
+++ b/spec/hashie/clash_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Hashie::Clash do
-  subject { Hashie::Clash.new }
-
   it 'is able to set an attribute via method_missing' do
     subject.foo('bar')
     expect(subject[:foo]).to eq 'bar'
@@ -44,5 +42,29 @@ describe Hashie::Clash do
     expect(subject).to eq(baz: 123, hgi: 123)
     expect(subject[:foo]).to be_nil
     expect(subject[:hello]).to be_nil
+  end
+
+  it 'merges multiple bang notation calls' do
+    subject.where!.foo(123)
+    subject.where!.bar(321)
+    expect(subject).to eq(where: { foo: 123, bar: 321 })
+  end
+
+  it 'raises an exception when method is missing' do
+    expect { subject.boo }.to raise_error(NoMethodError)
+  end
+
+  describe 'when inherited' do
+    subject { Class.new(described_class).new }
+
+    it 'bang nodes are instances of a subclass' do
+      subject.where!.foo(123)
+      expect(subject[:where]).to be_instance_of(subject.class)
+    end
+
+    it 'merged nodes are instances of a subclass' do
+      subject.where(abc: 'def').where(hgi: 123)
+      expect(subject[:where]).to be_instance_of(subject.class)
+    end
   end
 end


### PR DESCRIPTION
Added inheritance

Added multiple bang notation merging

Minor performace improvements - ends_with? is faster than regexp

By @bartoszkopinski, rebased against latest `master`

/cc @dblock