### PR TITLE
Fix `#merge` breaking indifferent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#319](https://github.com/intridea/hashie/pull/319): Fix a regression from 3.4.1 where `Hashie::Extensions::DeepFind` is no longer indifference-aware - [@michaelherold](https://github.com/michaelherold).
 * [#240](https://github.com/intridea/hashie/pull/240): Fixed nesting twice with Clash keys - [@bartoszkopinski](https://github.com/bartoszkopinski).
 * [#322](https://github.com/intridea/hashie/pull/322): Fixed `reverse_merge` issue with `Mash` subclasses - [@marshall-lee](https://github.com/marshall-lee).
+* [#346](https://github.com/intridea/hashie/pull/346): Fixed `merge` breaking indifferent access - [@docwhat](https://github.com/docwhat), [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## 3.4.3 (10/25/2015)

--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -133,6 +133,14 @@ module Hashie
         self
       end
 
+      def merge(*)
+        super.convert!
+      end
+
+      def merge!(*)
+        super.convert!
+      end
+
       protected
 
       def hash_lacking_indifference?(other)

--- a/spec/hashie/extensions/indifferent_access_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_spec.rb
@@ -31,6 +31,32 @@ describe Hashie::Extensions::IndifferentAccess do
     property :foo
   end
 
+  describe '#merge' do
+    it 'indifferently merges in a hash' do
+      indifferent_hash = Class.new(::Hash) do
+        include Hashie::Extensions::IndifferentAccess
+      end.new
+
+      merged_hash = indifferent_hash.merge(:cat => 'meow')
+
+      expect(merged_hash[:cat]).to eq('meow')
+      expect(merged_hash['cat']).to eq('meow')
+    end
+  end
+
+  describe '#merge!' do
+    it 'indifferently merges in a hash' do
+      indifferent_hash = Class.new(::Hash) do
+        include Hashie::Extensions::IndifferentAccess
+      end.new
+
+      indifferent_hash.merge!(:cat => 'meow')
+
+      expect(indifferent_hash[:cat]).to eq('meow')
+      expect(indifferent_hash['cat']).to eq('meow')
+    end
+  end
+
   describe 'when included in dash' do
     let(:params) { { foo: 'bar' } }
     subject { IndifferentHashWithDash.new(params) }


### PR DESCRIPTION
`HashWithDifferentAccess` wasn't properly setting the indifferent
access when merging in other hashes. This reruns `#convert!` after
calling the superclass implementation of the method, so it preserves
indifferent access on the resulting object.

Fixes #345