### PR TITLE
Convert Mash keys for #dig

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 171
+  Max: 176
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ scheme are considered to be bugs.
 
 ### Added
 
-* Nothing yet.
+* [#349](https://github.com/intridea/hashie/pull/349): Convert `Hashie::Mash#dig` arguments for Ruby 2.3.0 - [@k0kubun](https://github.com/k0kubun).
 
 ### Changed
 

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -250,6 +250,12 @@ module Hashie
       self.class.new(other_hash).merge(self)
     end
 
+    if RUBY_VERSION >= '2.3.0'
+      def dig(*keys)
+        super(*keys.map { |key| convert_key(key) })
+      end
+    end
+
     protected
 
     def method_name_and_suffix(method_name)

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -686,4 +686,15 @@ describe Hashie::Mash do
       end
     end
   end
+
+  if RUBY_VERSION >= '2.3.0'
+    describe '#dig' do
+      subject { described_class.new(a: { b: 1 }) }
+
+      it 'accepts both string and symbol as key' do
+        expect(subject.dig(:a, :b)).to eq(1)
+        expect(subject.dig('a', 'b')).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In Ruby 2.3.0, I want to use `Hash#dig` with symbol arguments for Mash.