### PR TITLE
Stringified translations wasn't working in IgnoreUndeclared.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ scheme are considered to be bugs.
 * [#319](https://github.com/intridea/hashie/pull/319): Fix a regression from 3.4.1 where `Hashie::Extensions::DeepFind` is no longer indifference-aware - [@michaelherold](https://github.com/michaelherold).
 * [#322](https://github.com/intridea/hashie/pull/322): Fixed `reverse_merge` issue with `Mash` subclasses - [@marshall-lee](https://github.com/marshall-lee).
 * [#346](https://github.com/intridea/hashie/pull/346): Fixed `merge` breaking indifferent access - [@docwhat](https://github.com/docwhat), [@michaelherold](https://github.com/michaelherold).
+* [#350](https://github.com/intridea/hashie/pull/350): Fixed from string translations used with `IgnoreUndeclared` - [@marshall-lee](https://github.com/marshall-lee).
 
 ### Security
 

--- a/lib/hashie/extensions/ignore_undeclared.rb
+++ b/lib/hashie/extensions/ignore_undeclared.rb
@@ -31,7 +31,7 @@ module Hashie
     module IgnoreUndeclared
       def initialize_attributes(attributes)
         attributes.each_pair do |att, value|
-          next unless self.class.property?(att) || (self.class.respond_to?(:translations) && self.class.translations.include?(att.to_sym))
+          next unless self.class.property?(att) || (self.class.respond_to?(:translations) && self.class.translations.include?(att))
           self[att] = value
         end if attributes
       end

--- a/lib/hashie/extensions/ignore_undeclared.rb
+++ b/lib/hashie/extensions/ignore_undeclared.rb
@@ -30,10 +30,13 @@ module Hashie
     #   p.email      # => NoMethodError
     module IgnoreUndeclared
       def initialize_attributes(attributes)
+        return unless attributes
+        klass = self.class
+        translations = klass.respond_to?(:translations) && klass.translations
         attributes.each_pair do |att, value|
-          next unless self.class.property?(att) || (self.class.respond_to?(:translations) && self.class.translations.include?(att))
+          next unless klass.property?(att) || (translations && translations.include?(att))
           self[att] = value
-        end if attributes
+        end
       end
 
       def property_exists?(property)

--- a/spec/hashie/extensions/ignore_undeclared_spec.rb
+++ b/spec/hashie/extensions/ignore_undeclared_spec.rb
@@ -6,6 +6,7 @@ describe Hashie::Extensions::IgnoreUndeclared do
       include Hashie::Extensions::IgnoreUndeclared
       property :city
       property :state, from: :provence
+      property :str_state, from: 'str_provence'
     end
 
     subject { ForgivingTrash }
@@ -19,7 +20,7 @@ describe Hashie::Extensions::IgnoreUndeclared do
     end
 
     it 'works with translated properties (with string keys)' do
-      expect(subject.new(provence: 'Ontario').state).to eq('Ontario')
+      expect(subject.new('str_provence' => 'Ontario').str_state).to eq('Ontario')
     end
 
     it 'requires properties to be declared on assignment' do


### PR DESCRIPTION
Translation from `:symbol` and translation from `'string'` are different translations. No need in coercion to symbol or some other coercions.