### PR TITLE
Checking for explicit definition of ActiveSupport::HashWithIndifferentAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ scheme are considered to be bugs.
 ### Fixed
 
 * [#358](https://github.com/intridea/hashie/pull/358): Fix support for Array#dig - [@modosc](https://github.com/modosc/).
+* [#365](https://github.com/intridea/hashie/pull/365): Ensure ActiveSupport#HashWithIndifferentAccess is defined before use in #deep_locate  - [@mikejarema](https://github.com/mikejarema/).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ scheme are considered to be bugs.
 ### Fixed
 
 * [#358](https://github.com/intridea/hashie/pull/358): Fix support for Array#dig - [@modosc](https://github.com/modosc/).
-* [#365](https://github.com/intridea/hashie/pull/365): Ensure ActiveSupport#HashWithIndifferentAccess is defined before use in #deep_locate  - [@mikejarema](https://github.com/mikejarema/).
+* [#365](https://github.com/intridea/hashie/pull/365): Ensure ActiveSupport::HashWithIndifferentAccess is defined before use in #deep_locate  - [@mikejarema](https://github.com/mikejarema/).
 
 ### Security
 

--- a/lib/hashie/extensions/deep_locate.rb
+++ b/lib/hashie/extensions/deep_locate.rb
@@ -64,7 +64,7 @@ module Hashie
       private
 
       def self._construct_key_comparator(search_key, object)
-        search_key = search_key.to_s if defined?(::ActiveSupport) && object.is_a?(::ActiveSupport::HashWithIndifferentAccess)
+        search_key = search_key.to_s if defined?(::ActiveSupport::HashWithIndifferentAccess) && object.is_a?(::ActiveSupport::HashWithIndifferentAccess)
         search_key = search_key.to_s if object.respond_to?(:indifferent_access?) && object.indifferent_access?
 
         lambda do |non_callable_object|


### PR DESCRIPTION
Hashie's current code assumes that the definition of `ActiveSupport` implies `HashWithIndifferentAccess` has been `require`d at some point. This assumption doesn't necessarily hold in all situations, so I've adjusted the conditional to check for the definition of `ActiveSupport::HashWithIndifferentAccess` explicitly.

I'm unable to create an example within `spec/hashie/extensions/deep_locate_spec.rb` that demonstrates this because `HashWithIndifferentAccess` has already been required. Nor am I aware of how to adjust `require`s within a spec or spec suite to achieve the same effect.

So I've created the following gist which, when run in isolation (`hashie` and `activesupport` gems installed), demonstrates the failure I encountered: 
https://gist.github.com/mikejarema/7617539662308a8fbcfcd76cec64649e