### PR TITLE
Since hashie/mash can be required alone, require its dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ scheme are considered to be bugs.
 
 ### Fixed
 
-* Your contribution here.
+* [#368](https://github.com/intridea/hashie/pull/368): Since `hashie/mash` can be required alone, require its dependencies - [@jrafanie](https://github.com/jrafanie).
 
 ### Security
 

--- a/lib/hashie/array.rb
+++ b/lib/hashie/array.rb
@@ -1,3 +1,6 @@
+require 'hashie/extensions/array/pretty_inspect'
+require 'hashie/extensions/ruby_version_check'
+
 module Hashie
   class Array < ::Array
     include Hashie::Extensions::Array::PrettyInspect


### PR DESCRIPTION
Fixes #367

While it's probably not something hashie wants to allow, previously
this was possible so we shouldn't break this when going 3.4.4 to 3.4.5.

As an example, omniauth requires [hashie/mash alone](https://github.com/omniauth/omniauth/blob/d941c4bcb1eb52f3674dd46225808751dd6a1c2f/lib/omniauth/auth_hash.rb#L1)

This appears to have been broken in #358.

Note, we can't write a test for this because we require 'hashie' in the spec_helper
which properly defines the [Hashie::Extensions::Array constant and autoloads
the pretty_inspect here](https://github.com/intridea/hashie/blob/229ee36d7c6a07eff6d8a0434726e12b8c3a0223/lib/hashie.rb#L48)

**Before**

```
10:44:30 ~/Code/hashie (master) (2.3.1) + be irb
irb(main):001:0> require 'hashie/mash'
NameError: uninitialized constant Hashie::Extensions::Array
Did you mean?  Hashie::Array
               Array
  from /Users/joerafaniello/Code/hashie/lib/hashie/array.rb:3:in `<class:Array>'
  from /Users/joerafaniello/Code/hashie/lib/hashie/array.rb:2:in `<module:Hashie>'
  from /Users/joerafaniello/Code/hashie/lib/hashie/array.rb:1:in `<top (required)>'
  from /Users/joerafaniello/Code/hashie/lib/hashie/mash.rb:2:in `require'
  from /Users/joerafaniello/Code/hashie/lib/hashie/mash.rb:2:in `<top (required)>'
  ...
```

**After**

```
10:44:40 ~/Code/hashie (master) (2.3.1) + be irb
irb(main):001:0> require 'hashie/mash'
=> true
irb(main):002:0> exit
```