### PR TITLE
Use existing translations when using IndifferentAccess and IgnoreUndeclared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ scheme are considered to be bugs.
 
 ### Fixed
 
-* Your contribution here.
+* [#369](https://github.com/intridea/hashie/pull/369): If a translation for a property exists when using IndifferentAccess and IgnoreUndeclared, use the translation to find the property - [@whitethunder](https://github.com/whitethunder).
 
 ### Security
 

--- a/lib/hashie/extensions/dash/indifferent_access.rb
+++ b/lib/hashie/extensions/dash/indifferent_access.rb
@@ -11,6 +11,7 @@ module Hashie
           # Check to see if the specified property has already been
           # defined.
           def property?(name)
+            name = translations[name.to_sym] if included_modules.include?(Hashie::Extensions::Dash::PropertyTranslation) && translation_exists?(name)
             name = name.to_s
             !!properties.find { |property| property.to_s == name }
           end
@@ -21,7 +22,7 @@ module Hashie
           end
 
           def transformed_property(property_name, value)
-            transform = transforms[property_name] || transforms[:"#{property_name}"]
+            transform = transforms[property_name] || transforms[property_name.to_sym]
             transform.call(value)
           end
 

--- a/spec/hashie/extensions/indifferent_access_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_spec.rb
@@ -31,6 +31,13 @@ describe Hashie::Extensions::IndifferentAccess do
     property :foo
   end
 
+  class IndifferentHashWithIgnoreUndeclaredAndPropertyTranslation < Hashie::Dash
+    include Hashie::Extensions::IgnoreUndeclared
+    include Hashie::Extensions::Dash::PropertyTranslation
+    include Hashie::Extensions::IndifferentAccess
+    property :foo, from: :bar
+  end
+
   describe '#merge' do
     it 'indifferently merges in a hash' do
       indifferent_hash = Class.new(::Hash) do
@@ -63,6 +70,36 @@ describe Hashie::Extensions::IndifferentAccess do
 
     it 'initialize with a symbol' do
       expect(subject.foo).to eq params[:foo]
+    end
+  end
+
+  describe 'when translating properties and ignoring undeclared' do
+    let(:value) { 'baz' }
+
+    subject { IndifferentHashWithIgnoreUndeclaredAndPropertyTranslation.new(params) }
+
+    context 'and the hash keys are strings' do
+      let(:params) { { 'bar' => value } }
+
+      it 'sets the property' do
+        expect(subject[:foo]).to eq value
+      end
+    end
+
+    context 'and the hash keys are symbols' do
+      let(:params) { { bar: 'baz' } }
+
+      it 'sets the property' do
+        expect(subject[:foo]).to eq value
+      end
+    end
+
+    context 'and there are undeclared keys' do
+      let(:params) { { 'bar' => 'baz', 'fail' => false } }
+
+      it 'sets the property' do
+        expect(subject[:foo]).to eq value
+      end
     end
   end
 


### PR DESCRIPTION
When using `Hashie::Extensions::Dash::IndifferentAccess` and `Hashie::Extensions::Dash::PropertyTranslation` at the same time, Hashie does not use the translation when accessing properties via `IndifferentAccess`. This modifies `IndifferentAccess` to look for a translation first and use it to access the property.