### PR TITLE
Fix dig bug for Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ scheme are considered to be bugs.
 ### Fixed
 
 * [#369](https://github.com/intridea/hashie/pull/369): If a translation for a property exists when using IndifferentAccess and IgnoreUndeclared, use the translation to find the property - [@whitethunder](https://github.com/whitethunder).
+* [#376](https://github.com/intridea/hashie/pull/376): Leave string index unchanged if it can't be converted to integer for Array#dig - [@sazor](https://github.com/sazor).
 
 ### Security
 

--- a/lib/hashie/array.rb
+++ b/lib/hashie/array.rb
@@ -7,7 +7,14 @@ module Hashie
     include Hashie::Extensions::RubyVersionCheck
     with_minimum_ruby('2.3.0') do
       def dig(*indexes)
-        super(*indexes.map { |idx| Integer(idx) })
+        converted_indexes = indexes.map do |idx|
+          begin
+            Integer(idx)
+          rescue ArgumentError
+            idx
+          end
+        end
+        super(*converted_indexes)
       end
     end
   end

--- a/spec/hashie/array_spec.rb
+++ b/spec/hashie/array_spec.rb
@@ -12,6 +12,18 @@ describe Array do
       it 'works with a numeric index' do
         expect(array.dig(1)).to eq(:b)
       end
+
+      context 'when array is empty' do
+        let(:array) { Hashie::Array.new([]) }
+
+        it 'works with a first numeric and next string index' do
+          expect(array.dig(0, 'hello')).to eq(nil)
+        end
+
+        it 'throws an error with first string and next numeric index' do
+          expect { array.dig('hello', 0) }.to raise_error(TypeError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I've fixed #373 bug. Issue was caused by trying to convert strings to integers. Default ruby implementation doesn't support it. So my approach is make an attempt to convert string and in case of failure just leave unconverted value to be handled by default #dig method. By doing this we save conversion feature while staying close to original implementation. Made it explicit block to be sure which exception could we catch.