### PR TITLE
Check ruby version without rubygems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ scheme are considered to be bugs.
 
 * [#369](https://github.com/intridea/hashie/pull/369): If a translation for a property exists when using IndifferentAccess and IgnoreUndeclared, use the translation to find the property - [@whitethunder](https://github.com/whitethunder).
 * [#376](https://github.com/intridea/hashie/pull/376): Leave string index unchanged if it can't be converted to integer for Array#dig - [@sazor](https://github.com/sazor).
+* [#377](https://github.com/intridea/hashie/pull/377): Dont use Rubygems to check ruby version - [@sazor](https://github.com/sazor).
 
 ### Security
 

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -27,8 +27,9 @@ module Hashie
     autoload :PrettyInspect,     'hashie/extensions/pretty_inspect'
     autoload :KeyConversion,     'hashie/extensions/key_conversion'
     autoload :MethodAccessWithOverride, 'hashie/extensions/method_access'
-    autoload :StrictKeyAccess, 'hashie/extensions/strict_key_access'
-    autoload :RubyVersionCheck, 'hashie/extensions/ruby_version_check'
+    autoload :StrictKeyAccess,   'hashie/extensions/strict_key_access'
+    autoload :RubyVersion,       'hashie/extensions/ruby_version'
+    autoload :RubyVersionCheck,  'hashie/extensions/ruby_version_check'
 
     module Parsers
       autoload :YamlErbParser, 'hashie/extensions/parsers/yaml_erb_parser'

--- a/lib/hashie/extensions/ruby_version.rb
+++ b/lib/hashie/extensions/ruby_version.rb
@@ -1,0 +1,60 @@
+# Copyright (c) Chad Fowler, Rich Kilmer, Jim Weirich and others.
+# Portions copyright (c) Engine Yard and Andre Arko
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# 'Software'), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+module Hashie
+  module Extensions
+    class RubyVersion
+      include Comparable
+
+      attr_accessor :segments
+
+      def initialize(version)
+        @segments = split_to_segments(version)
+      end
+
+      def <=>(other)
+        lhsegments = segments
+        rhsegments = other.segments
+
+        lhsize = lhsegments.size
+        rhsize = rhsegments.size
+        limit  = (lhsize > rhsize ? lhsize : rhsize) - 1
+
+        i = 0
+
+        while i <= limit
+          lhs = lhsegments[i] || 0
+          rhs = rhsegments[i] || 0
+          i += 1
+
+          next      if lhs == rhs
+          return -1 if lhs.is_a?(String) && rhs.is_a?(Numeric)
+          return  1 if lhs.is_a?(Numeric) && rhs.is_a?(String)
+
+          return lhs <=> rhs
+        end
+
+        0
+      end
+
+      private
+
+      def split_to_segments(version)
+        version.scan(/[0-9]+|[a-z]+/i).map do |segment|
+          /^\d+$/ =~ segment ? segment.to_i : segment
+        end.freeze
+      end
+    end
+  end
+end

--- a/lib/hashie/extensions/ruby_version_check.rb
+++ b/lib/hashie/extensions/ruby_version_check.rb
@@ -7,7 +7,7 @@ module Hashie
 
       module ClassMethods
         def with_minimum_ruby(version)
-          yield if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(version)
+          yield if RubyVersion.new(RUBY_VERSION) >= RubyVersion.new(version)
         end
       end
     end

--- a/spec/support/ruby_version_check.rb
+++ b/spec/support/ruby_version_check.rb
@@ -1,5 +1,6 @@
 module RubyVersionCheck
   def with_minimum_ruby(version)
-    yield if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(version)
+    yield if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+             Hashie::Extensions::RubyVersion.new(version)
   end
 end


### PR DESCRIPTION
This is a solution for #375. Moved only required parts of Gem::Version including Copyright. I cant find any significant causes to implement new comparison method.