### PR TITLE
Deep find all goes inside all nested hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ scheme are considered to be bugs.
 * [#369](https://github.com/intridea/hashie/pull/369): If a translation for a property exists when using IndifferentAccess and IgnoreUndeclared, use the translation to find the property - [@whitethunder](https://github.com/whitethunder).
 * [#376](https://github.com/intridea/hashie/pull/376): Leave string index unchanged if it can't be converted to integer for Array#dig - [@sazor](https://github.com/sazor).
 * [#377](https://github.com/intridea/hashie/pull/377): Dont use Rubygems to check ruby version - [@sazor](https://github.com/sazor).
+* [#378](https://github.com/intridea/hashie/pull/378): Deep find all searches inside all nested hashes - [@sazor](https://github.com/sazor).
 
 ### Security
 

--- a/lib/hashie/extensions/deep_locate.rb
+++ b/lib/hashie/extensions/deep_locate.rb
@@ -76,10 +76,9 @@ module Hashie
         if object.is_a?(::Enumerable)
           if object.any? { |value| _match_comparator?(value, comparator, object) }
             result.push object
-          else
-            (object.respond_to?(:values) ? object.values : object.entries).each do |value|
-              _deep_locate(comparator, value, result)
-            end
+          end
+          (object.respond_to?(:values) ? object.values : object.entries).each do |value|
+            _deep_locate(comparator, value, result)
           end
         end
 

--- a/spec/hashie/extensions/deep_find_spec.rb
+++ b/spec/hashie/extensions/deep_find_spec.rb
@@ -42,6 +42,31 @@ describe Hashie::Extensions::DeepFind do
     it 'returns nil if it does not find any matches' do
       expect(instance.deep_find_all(:wahoo)).to be_nil
     end
+
+    context 'when match value is hash itself' do
+      let(:hash) do
+        {
+          title: {
+            type: :string
+          },
+          library: {
+            books: [
+              { title: 'Call of the Wild' },
+              { title: 'Moby Dick' }
+            ],
+            shelves: nil,
+            location: {
+              address: '123 Library St.',
+              title: 'Main Library'
+            }
+          }
+        }
+      end
+
+      it 'detects all values from a nested hash' do
+        expect(instance.deep_find_all(:title)).to eq([{ type: :string }, 'Call of the Wild', 'Moby Dick', 'Main Library'])
+      end
+    end
   end
 
   context 'on an ActiveSupport::HashWithIndifferentAccess' do


### PR DESCRIPTION
These changes fix #364 (and #327) issue. Problem appeared in case when current hash has such key. Then deep_locate just pushes this hash into result and doesn't go deeper. After that deep_find fetches value from result hashes by key so only top-level value goes into final result. Still not sure if it should be handled by deep_locate (as in this pr) or deep_find itself should do something smarter.