### PR TITLE
Coercion type systems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
   gem 'activesupport', '~> 5.x', require: false
   gem 'activemodel', '~> 5.x', require: false
+  gem 'dry-types', require: false
   gem 'codeclimate-test-reporter', require: false
   gem 'rspec-core', '~> 3.1.7'
   gem 'danger-changelog', '~> 0.1.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
   gem 'activesupport', '~> 5.x', require: false
+  gem 'activemodel', '~> 5.x', require: false
   gem 'codeclimate-test-reporter', require: false
   gem 'rspec-core', '~> 3.1.7'
   gem 'danger-changelog', '~> 0.1.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
-  gem 'activesupport', '~> 4.x', require: false
+  gem 'activesupport', '~> 5.x', require: false
   gem 'codeclimate-test-reporter', require: false
   gem 'rspec-core', '~> 3.1.7'
   gem 'danger-changelog', '~> 0.1.0', require: false

--- a/README.md
+++ b/README.md
@@ -30,6 +30,54 @@ Any of the extensions listed below can be mixed into a class by `include`-ing `H
 
 ### Coercion
 
+Three systems are available for coercion: ActiveModel types, dry-types, and hashie's builtin types. The use of a specified coercion system is determined by exactly which Coercion module yo include in your Hashie class. Including the default `Hashie::Extensions::Coercion` module will use Hashie's builtin type system.
+
+### Coercion using ActiveModel types
+
+To use ActiveModel's type coercion system, you must add version 5 of ActiveModel to your Gemfile. If you are using Rails, activemodel is included, but you must be using Rail's version 5 in order to use this. If you are on running a lower version of Rails, you will not be able to use ActiveModel's type coercion system due to Ruby's inability to use different Gem versions in the same application.
+
+```ruby
+gem 'activemodel', '~> 5.x'
+```
+
+Then include the `active_model` Coercion module into your Hashie class:
+
+```ruby
+class Tweet < Hash
+  include Hashie::Extensions::Coercion.active_model
+  coerce_key :count, :integer
+end
+```
+
+The following types are available through ActiveModel::Type. The symbol type has been added by Hashie.
+
+```ruby
+[:big_integer, :binary, :boolean, :date, :datetime, :decimal, :float, :immutable_string, :integer, :string, :text, :time, :symbol]
+```
+
+The `cast` or `cast_value` methods on the `ActiveModel::Type` class are used, `serialize` and `deserialize` are for database interaactions and may be ignored in this context. Read more about ActiveModel::Type here: https://github.com/rails/rails/tree/5-0-stable/activemodel/lib/active_model/type
+
+### Coercion using dry-types
+
+Dry-types is by far the most fully featured and granular type coercion system available for use with Hashie. To use, you must add the dry-types gem to your application's Gemfile.
+
+```ruby
+gem 'dry-types'
+```
+
+Then include the `dry_types` Coercion module into your Hashie class:
+
+```ruby
+class Tweet < Hash
+  include Hashie::Extensions::Coercion.dry_types
+  coerce_key :count, Types::Coercible::Int
+end
+```
+
+Dry-types has far too many types and type constraints available to list here. Please read the documentation to learn what is available: http://dry-rb.org/gems/dry-types/built-in-types/.
+
+### Coercion
+
 Coercions allow you to set up "coercion rules" based either on the key or the value type to massage data as it's being inserted into the Hash. Key coercions might be used, for example, in lightweight data modeling applications such as an API client:
 
 ```ruby

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -34,6 +34,7 @@ module Hashie
     module Coercion
       autoload :HashieTypes, 'hashie/extensions/coercion/hashie_types'
       autoload :ActiveModel, 'hashie/extensions/coercion/active_model'
+      autoload :DryTypes,    'hashie/extensions/coercion/dry_types'
     end
 
     module Parsers

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -32,7 +32,8 @@ module Hashie
     autoload :RubyVersionCheck,  'hashie/extensions/ruby_version_check'
 
     module Coercion
-      autoload :HashieTypes,     'hashie/extensions/coercion/hashie_types'
+      autoload :HashieTypes, 'hashie/extensions/coercion/hashie_types'
+      autoload :ActiveModel, 'hashie/extensions/coercion/active_model'
     end
 
     module Parsers

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -31,6 +31,10 @@ module Hashie
     autoload :RubyVersion,       'hashie/extensions/ruby_version'
     autoload :RubyVersionCheck,  'hashie/extensions/ruby_version_check'
 
+    module Coercion
+      autoload :HashieTypes,     'hashie/extensions/coercion/hashie_types'
+    end
+
     module Parsers
       autoload :YamlErbParser, 'hashie/extensions/parsers/yaml_erb_parser'
     end

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -3,27 +3,58 @@ module Hashie
 
   module Extensions
     module Coercion
-      CORE_TYPES = {
-        Integer    => :to_i,
-        Float      => :to_f,
-        Complex    => :to_c,
-        Rational   => :to_r,
-        String     => :to_s,
-        Symbol     => :to_sym
-      }
-
       ABSTRACT_CORE_TYPES = {
         Integer => [Fixnum, Bignum],
         Numeric => [Fixnum, Bignum, Float, Complex, Rational]
       }
 
-      def self.included(base)
-        base.send :include, InstanceMethods
-        base.extend ClassMethods # NOTE: we wanna make sure we first define set_value_with_coercion before extending
+      class CoercionSystemIncludeBuilder < Module
+        def initialize(&common_included_block)
+          @common_included_block = common_included_block
+        end
 
-        base.send :alias_method, :set_value_without_coercion, :[]= unless base.method_defined?(:set_value_without_coercion)
+        def define_include_type_method(base_module, name, &type_system_block)
+          common_included_block = @common_included_block
+          base_module.define_singleton_method name do
+            Module.new.tap do |mod|
+              mod.define_singleton_method :included do |base|
+                instance_exec(base, &common_included_block)
+                instance_exec(base, &type_system_block)
+              end
+            end
+          end
+        end
+
+        def define_default_included(base_module, &default_system_block)
+          common_included_block = @common_included_block
+          base_module.define_singleton_method :included do |base|
+            instance_exec(base, &common_included_block)
+            instance_exec(base, &default_system_block)
+          end
+        end
+
+        # New Coercion systems must override the base_class here.
+        def extended(base)
+          define_default_included base do |base_class|
+            puts 'DEFAULT'
+            base_class.extend HashieTypes
+          end
+          define_include_type_method base, :active_model do |base_class|
+            puts 'ACTIVE_MODEL'
+          end
+        end
+      end
+
+      includer = CoercionSystemIncludeBuilder.new do |base|
+        puts 'COMMON'
+        base.include InstanceMethods
+        base.extend ClassMethods
+        unless base.method_defined?(:set_value_without_coercion)
+          base.send :alias_method, :set_value_without_coercion, :[]=
+        end
         base.send :alias_method, :[]=, :set_value_with_coercion
       end
+      extend includer
 
       module InstanceMethods
         def set_value_with_coercion(key, value)
@@ -153,59 +184,12 @@ module Hashie
           end
         end
 
-        def build_coercion(type)
-          if type.is_a? Enumerable
-            if type.class <= ::Hash
-              type, key_type, value_type = type.class, *type.first
-              build_hash_coercion(type, key_type, value_type)
-            else # Enumerable but not Hash: Array, Set
-              value_type = type.first
-              type = type.class
-              build_container_coercion(type, value_type)
-            end
-          elsif CORE_TYPES.key? type
-            build_core_type_coercion(type)
-          elsif type.respond_to? :coerce
-            lambda do |value|
-              return value if value.is_a? type
-              type.coerce(value)
-            end
-          elsif type.respond_to? :new
-            lambda do |value|
-              return value if value.is_a? type
-              type.new(value)
-            end
-          else
-            fail TypeError, "#{type} is not a coercable type"
-          end
-        end
-
-        def build_hash_coercion(type, key_type, value_type)
-          key_coerce = fetch_coercion(key_type)
-          value_coerce = fetch_coercion(value_type)
-          lambda do |value|
-            type[value.map { |k, v| [key_coerce.call(k), value_coerce.call(v)] }]
-          end
-        end
-
-        def build_container_coercion(type, value_type)
-          value_coerce = fetch_coercion(value_type)
-          lambda do |value|
-            type.new(value.map { |v| value_coerce.call(v) })
-          end
-        end
-
-        def build_core_type_coercion(type)
-          name = CORE_TYPES[type]
-          lambda do |value|
-            return value if value.is_a? type
-            return value.send(name)
-          end
+        def build_coercion
+          raise 'This method must be replaced'
         end
 
         def inherited(klass)
           super
-
           klass.key_coercions = key_coercions.dup
         end
       end

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -9,6 +9,8 @@ module Hashie
       }
 
       class CoercionSystemIncludeBuilder < Module
+        attr_reader :common_included_block
+
         def initialize(&common_included_block)
           @common_included_block = common_included_block
         end
@@ -36,7 +38,6 @@ module Hashie
         # New Coercion systems must override the base_class here.
         def extended(base)
           define_default_included base do |base_class|
-            puts 'DEFAULT'
             base_class.extend HashieTypes
           end
           define_include_type_method base, :active_model do |base_class|
@@ -45,8 +46,7 @@ module Hashie
         end
       end
 
-      includer = CoercionSystemIncludeBuilder.new do |base|
-        puts 'COMMON'
+      Includer = CoercionSystemIncludeBuilder.new do |base|
         base.include InstanceMethods
         base.extend ClassMethods
         unless base.method_defined?(:set_value_without_coercion)
@@ -54,7 +54,7 @@ module Hashie
         end
         base.send :alias_method, :[]=, :set_value_with_coercion
       end
-      extend includer
+      extend Includer
 
       module InstanceMethods
         def set_value_with_coercion(key, value)

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -43,6 +43,10 @@ module Hashie
           define_include_type_method base, :active_model do |base_class|
             base_class.extend ActiveModel
           end
+          define_include_type_method base, :dry_types do |base_class|
+            base_class.extend DryTypes
+            base_class.const_set('Types', DryTypes::Types)
+          end
         end
       end
 

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -45,7 +45,6 @@ module Hashie
           end
           define_include_type_method base, :dry_types do |base_class|
             base_class.extend DryTypes
-            base_class.const_set('Types', DryTypes::Types)
           end
         end
       end

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -40,7 +40,7 @@ module Hashie
             base_class.extend HashieTypes
           end
           define_include_type_method base, :active_model do |base_class|
-            puts 'ACTIVE_MODEL'
+            base_class.extend ActiveModel
           end
         end
       end

--- a/lib/hashie/extensions/coercion/active_model.rb
+++ b/lib/hashie/extensions/coercion/active_model.rb
@@ -1,6 +1,5 @@
 require 'active_model/type'
 
-
 module Hashie
   module Extensions
     module Coercion

--- a/lib/hashie/extensions/coercion/active_model.rb
+++ b/lib/hashie/extensions/coercion/active_model.rb
@@ -1,0 +1,63 @@
+require 'active_model/type'
+
+
+module Hashie
+  module Extensions
+    module Coercion
+      module ActiveModel
+        # Symbol is the one glaring type omission. Define it quick.
+        class Symbol < ::ActiveModel::Type::String
+          def type; :symbol; end
+          private
+          def cast_value(value); super.to_sym; end
+        end
+        ::ActiveModel::Type.register(:symbol, Symbol)
+
+        # Array of symbols of the included ActiveModel types.
+        ACTIVE_MODEL_TYPES = ::ActiveModel::Type.registry
+                                                .send(:registrations)
+                                                .map { |r| r.send(:name) }
+                                                .freeze
+
+        def build_coercion(type)
+          if type.is_a? Enumerable
+            if type.class <= ::Hash
+              type, key_type, value_type = type.class, *type.first
+              build_hash_coercion(type, key_type, value_type)
+            else # Enumerable but not Hash: Array, Set
+              value_type = type.first
+              type = type.class
+              build_container_coercion(type, value_type)
+            end
+          elsif ACTIVE_MODEL_TYPES.include? type
+            build_active_model_type_coercion(type)
+          else
+            fail TypeError, "#{type} is not a coercable type"
+          end
+        end
+
+        def build_hash_coercion(type, key_type, value_type)
+          key_coerce = fetch_coercion(key_type)
+          value_coerce = fetch_coercion(value_type)
+          lambda do |value|
+            type[value.map { |k, v| [key_coerce.call(k), value_coerce.call(v)] }]
+          end
+        end
+
+        def build_container_coercion(type, value_type)
+          value_coerce = fetch_coercion(value_type)
+          lambda do |value|
+            type.new(value.map { |v| value_coerce.call(v) })
+          end
+        end
+
+        def build_active_model_type_coercion(type)
+          active_model_type = ::ActiveModel::Type.lookup(type)
+          lambda do |value|
+            return active_model_type.cast(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hashie/extensions/coercion/dry_types.rb
+++ b/lib/hashie/extensions/coercion/dry_types.rb
@@ -1,0 +1,23 @@
+require 'dry-types'
+
+module Hashie
+  module Extensions
+    module Coercion
+      module DryTypes
+        module Types
+          include Dry::Types.module
+        end
+
+        def build_coercion(type)
+          if type.respond_to? :call
+            lambda do |value|
+              return type.call(value)
+            end
+          else
+            fail TypeError, "#{type} is not a coercable type"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hashie/extensions/coercion/dry_types.rb
+++ b/lib/hashie/extensions/coercion/dry_types.rb
@@ -8,6 +8,10 @@ module Hashie
           include Dry::Types.module
         end
 
+        def self.extended(base)
+          base.const_set('Types', Types)
+        end
+
         def build_coercion(type)
           if type.respond_to? :call
             lambda do |value|

--- a/lib/hashie/extensions/coercion/hashie_types.rb
+++ b/lib/hashie/extensions/coercion/hashie_types.rb
@@ -1,0 +1,66 @@
+module Hashie
+  module Extensions
+    module Coercion
+      module HashieTypes
+        CORE_TYPES = {
+          Integer    => :to_i,
+          Float      => :to_f,
+          Complex    => :to_c,
+          Rational   => :to_r,
+          String     => :to_s,
+          Symbol     => :to_sym
+        }
+
+        def build_coercion(type)
+          if type.is_a? Enumerable
+            if type.class <= ::Hash
+              type, key_type, value_type = type.class, *type.first
+              build_hash_coercion(type, key_type, value_type)
+            else # Enumerable but not Hash: Array, Set
+              value_type = type.first
+              type = type.class
+              build_container_coercion(type, value_type)
+            end
+          elsif CORE_TYPES.key? type
+            build_core_type_coercion(type)
+          elsif type.respond_to? :coerce
+            lambda do |value|
+              return value if value.is_a? type
+              type.coerce(value)
+            end
+          elsif type.respond_to? :new
+            lambda do |value|
+              return value if value.is_a? type
+              type.new(value)
+            end
+          else
+            fail TypeError, "#{type} is not a coercable type"
+          end
+        end
+
+        def build_hash_coercion(type, key_type, value_type)
+          key_coerce = fetch_coercion(key_type)
+          value_coerce = fetch_coercion(value_type)
+          lambda do |value|
+            type[value.map { |k, v| [key_coerce.call(k), value_coerce.call(v)] }]
+          end
+        end
+
+        def build_container_coercion(type, value_type)
+          value_coerce = fetch_coercion(value_type)
+          lambda do |value|
+            type.new(value.map { |v| value_coerce.call(v) })
+          end
+        end
+
+        def build_core_type_coercion(type)
+          name = CORE_TYPES[type]
+          lambda do |value|
+            return value if value.is_a? type
+            return value.send(name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hashie/extensions/dash/coercion.rb
+++ b/lib/hashie/extensions/dash/coercion.rb
@@ -5,15 +5,11 @@ module Hashie
         includer = ::Hashie::Extensions::Coercion::CoercionSystemIncludeBuilder
                    .new do |base|
           # Extends a Dash with the ability to define coercion for properties.
-          base.send :include, Hashie::Extensions::Coercion
+          common = Hashie::Extensions::Coercion::Includer.common_included_block
+          instance_exec(base, &common)
           base.extend ClassMethods
         end
         extend includer
-
-        def self.included(base)
-          base.send :include, Hashie::Extensions::Coercion
-          base.extend ClassMethods
-        end
 
         module ClassMethods
           # Defines a property on the Dash. Options are the standard

--- a/lib/hashie/extensions/dash/coercion.rb
+++ b/lib/hashie/extensions/dash/coercion.rb
@@ -2,7 +2,13 @@ module Hashie
   module Extensions
     module Dash
       module Coercion
-        # Extends a Dash with the ability to define coercion for properties.
+        includer = ::Hashie::Extensions::Coercion::CoercionSystemIncludeBuilder
+                   .new do |base|
+          # Extends a Dash with the ability to define coercion for properties.
+          base.send :include, Hashie::Extensions::Coercion
+          base.extend ClassMethods
+        end
+        extend includer
 
         def self.included(base)
           base.send :include, Hashie::Extensions::Coercion


### PR DESCRIPTION
Introducing switchable type coercion systems for Hashie. Follows up on #239.

Adds 'dry-types' and 'activemodel' alongside Mashie's builtin coercion system. Basic usage is written up in the README.

For the most part, reading the source should be straight forward. The `coercion` folder under 'extensions' contains the implementation of the 3 coercion systems. The `Hashie::Extensions::Coercion` module was split into two files. The file itself contains the interface and common coercion methods, while the `Coercion::HashieTypes` class, now contains the actual coercion implementation.

The only confusing part is the `CoercionSystemIncludeBuilder` defined under `Hashie::Extensions::Coercion`. The purpose of this class is to DRY up the included hooks for ``Hashie::Extensions::Coercion` and `Hashie::Extensions::Dash::Coercion`. The common includes are defined once, and reused in the default `included` method and the `active_model` and `dry_types` methods on both the default and Dash coercion classes.

This is 100% backwards compatible and all the tests pass. I did not add any additional tests - we should not need many as the new coercion systems are well tested in their own repos. We may want to add a few tests though.