### PR TITLE
Dash default and as json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ scheme are considered to be bugs.
 * [#376](https://github.com/intridea/hashie/pull/376): Leave string index unchanged if it can't be converted to integer for Array#dig - [@sazor](https://github.com/sazor).
 * [#377](https://github.com/intridea/hashie/pull/377): Dont use Rubygems to check ruby version - [@sazor](https://github.com/sazor).
 * [#378](https://github.com/intridea/hashie/pull/378): Deep find all searches inside all nested hashes - [@sazor](https://github.com/sazor).
+* [#380](https://github.com/intridea/hashie/pull/380): Evaluate procs default values of Dash in object initialization - [@sazor](https://github.com/sazor).
 
 ### Security
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,18 @@
 Upgrading Hashie
 ================
 
+### Upgrading to 3.4.7
+
+#### Procs as default values for Dash
+
+```ruby
+class MyHash < Hashie::Dash
+  property :time, default: -> { Time.now }
+end
+```
+
+In versions < 3.4.7 `Time.now` will be evaluated when `time` property is accessed directly first time. 
+In version >= 3.4.7 `Time.now` is evaluated in time of object initialization.
 ### Upgrading to 3.4.4
 
 #### Mash subclasses and reverse_merge

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -97,7 +97,11 @@ module Hashie
       self.class.defaults.each_pair do |prop, value|
         self[prop] = begin
           val = value.dup
-          val.is_a?(Proc) && val.arity > 0 ? val.call(self) : val
+          if val.is_a?(Proc)
+            val.arity == 1 ? val.call(self) : val.call
+          else
+            val
+          end
         rescue TypeError
           value
         end

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -56,9 +56,9 @@ class DeferredWithSelfTest < Hashie::Dash
 end
 
 describe DashTestDefaultProc do
-  it "as_json behaves correctly with default proc" do
+  it 'as_json behaves correctly with default proc' do
     object = described_class.new
-    expect(object.as_json).to be == { "fields" => [] }
+    expect(object.as_json).to be == { 'fields' => [] }
   end
 end
 

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -12,6 +12,10 @@ class DashTest < Hashie::Dash
   property :count, default: 0
 end
 
+class DashTestDefaultProc < Hashie::Dash
+  property :fields, default: -> { [] }
+end
+
 class DashNoRequiredTest < Hashie::Dash
   property :first_name
   property :email
@@ -49,6 +53,13 @@ end
 class DeferredWithSelfTest < Hashie::Dash
   property :created_at, default: -> { Time.now }
   property :updated_at, default: ->(test) { test.created_at }
+end
+
+describe DashTestDefaultProc do
+  it "as_json behaves correctly with default proc" do
+    object = described_class.new
+    expect(object.as_json).to be == { "fields" => [] }
+  end
 end
 
 describe DashTest do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'hashie'
 require 'rspec/pending_for'
 require './spec/support/ruby_version_check'
 
-# NOTE: should this be here?
 require 'active_support'
 require 'active_support/core_ext'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ require 'hashie'
 require 'rspec/pending_for'
 require './spec/support/ruby_version_check'
 
+# NOTE: should this be here?
+require 'active_support'
+require 'active_support/core_ext'
+
 RSpec.configure do |config|
   config.extend RubyVersionCheck
   config.expect_with :rspec do |expect|


### PR DESCRIPTION
This change of behaviour fixes at least #362. All procs will be evaluated in object initialization (not only with arity = 1). It makes sense to me because i think that default values should return same values in all possible ways to access them (not only by [] method).
