### PR TITLE
Add MergeInitializer to Coercian example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Coercions allow you to set up "coercion rules" based either on the key or the va
 ```ruby
 class Tweet < Hash
   include Hashie::Extensions::Coercion
+  include Hashie::Extensions::MergeInitializer
   coerce_key :user, User
 end
 


### PR DESCRIPTION
Before:
```ruby
class Tweet < Hash
  include Hashie::Extensions::Coercion
  coerce_key :user, User
end

user_hash = { name: "Bob" }
Tweet.new(user: user_hash)
# => {}
```

After:
```ruby
class Tweet < Hash
  include Hashie::Extensions::Coercion
  include Hashie::Extensions::MergeInitializer
  coerce_key :user, User
end

user_hash = { name: "Bob" }
Tweet.new(user: user_hash)
#=> {:user=>#<struct User name={:name=>"Bob"}>}
```

Fixes #332 