### PR TITLE
Update to CodeClimate 1.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - rvm: 2.3.1
       script:
         - bundle exec danger
+        - bundle exec codeclimate-test-reporter
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ scheme are considered to be bugs.
 
 ### Changed
 
+* [#384](https://github.com/intridea/hashie/pull/384): Updated to CodeClimate 1.x - [@boffbowsh](https://github.com/boffbowsh).
 * Your contribution here.
 
 ### Deprecated

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
   gem 'activesupport', '~> 4.x', require: false
-  gem 'codeclimate-test-reporter', require: false
+  gem 'codeclimate-test-reporter', '~> 1.0', require: false
   gem 'rspec-core', '~> 3.1.7'
   gem 'danger-changelog', '~> 0.1.0', require: false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 if ENV['CI']
-  require 'codeclimate-test-reporter'
-  CodeClimate::TestReporter.start
+  require 'simplecov'
+  SimpleCov.start
 end
 
 require 'pry'


### PR DESCRIPTION
CodeClimate > 1.0 uses SimpleCov and requires the test reporter to be
called explicitly:

https://github.com/codeclimate/ruby-test-reporter/blob/master/CHANGELOG.
md#v100-2016-11-03