### PR TITLE
Fix #385 - deep merge by reference bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ scheme are considered to be bugs.
 
 ## [Unreleased][unreleased]
 
+* [#386](https://github.com/intridea/hashie/pull/386): Fix for #385: Make `deep_merge` always `deep_dup` nested hashes before merging them in so that there are no shared references between the two hashes being merged. - [@mltsy](https://github.com/mltsy).
+
 [3.4.7]: https://github.com/intridea/hashie/compare/v3.4.6...master
 
 ### Added

--- a/lib/hashie/extensions/deep_merge.rb
+++ b/lib/hashie/extensions/deep_merge.rb
@@ -26,7 +26,7 @@ module Hashie
                       if hash.key?(k) && block_given?
                         block.call(k, hash[k], v)
                       else
-                        v
+                        v.respond_to?(:deep_dup) ? v.deep_dup : v
                       end
                     end
         end

--- a/spec/hashie/extensions/deep_merge_spec.rb
+++ b/spec/hashie/extensions/deep_merge_spec.rb
@@ -14,8 +14,8 @@ describe Hashie::Extensions::DeepMerge do
 
   context 'without &block' do
     let(:h1) { subject.new.merge(a: 'a', a1: 42, b: 'b', c: { c1: 'c1', c2: { a: 'b' }, c3: { d1: 'd1' } }) }
-    let(:h2) { { a: 1, a1: 1, c: { c1: 2, c2: 'c2', c3: { d2: 'd2' } } } }
-    let(:expected_hash) { { a: 1, a1: 1, b: 'b', c: { c1: 2, c2: 'c2', c3: { d1: 'd1', d2: 'd2' } } } }
+    let(:h2) { { a: 1, a1: 1, c: { c1: 2, c2: 'c2', c3: { d2: 'd2' } }, e: { e1: 1 } } }
+    let(:expected_hash) { { a: 1, a1: 1, b: 'b', c: { c1: 2, c2: 'c2', c3: { d1: 'd1', d2: 'd2' } }, e: { e1: 1 } } }
 
     it 'deep merges two hashes' do
       expect(h1.deep_merge(h2)).to eq expected_hash
@@ -24,6 +24,11 @@ describe Hashie::Extensions::DeepMerge do
     it 'deep merges another hash in place via bang method' do
       h1.deep_merge!(h2)
       expect(h1).to eq expected_hash
+    end
+
+    it 'merges new nested hash entries by value, not by reference' do
+      h1.deep_merge!(h2)
+      expect { h1[:e][:e1] = 'changed' }.not_to change { h2[:e][:e1] }
     end
   end
 


### PR DESCRIPTION
This is a failing test for issue #385 - if you agree with this spec, I can submit a patch to have it `deep_dup` nested hashes before merging to make the test pass.