### PR TITLE
Fix builds breaking due to Rake 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ scheme are considered to be bugs.
 
 ### Miscellanous
 
+* [#387](https://github.com/intridea/hashie/pull/387): Fix builds failing due to Rake 11 having a breaking change - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## [3.4.6] - 2016-09-16

--- a/hashie.gemspec
+++ b/hashie.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files += Dir['spec/**/*.rb']
   gem.test_files = Dir['spec/**/*.rb']
 
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '< 11'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rspec-pending_for', '~> 0.1'
 end


### PR DESCRIPTION
Rake 11 has a breaking change (removal of the `#last_comment` method) that doesn't work with our current version of RSpec and Rubocop. Updating RSpec was simple, but we have to update so far in Rubocop that there were a ton of changes that would be required.

This clamps the version of Rake that we use to `< 11`. This should be a temporary fix, but will let us actually have passing builds on Travis again.