### PR TITLE
Move danger to before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
 matrix:
   include:
     - rvm: 2.3.1
-      script:
+      before_script:
         - bundle exec danger
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
When building master, the usual `bundle exec rake` script has been
replaced with `bundle exec danger`. This works fine in PRs as Danger is
set up to build PRs, but not against master.

This means that tests aren’t actually running for Ruby 2.3.1 in master.
Due to this, code coverage reports aren’t being generated, so the Code
Climate report uploader fails.

Making danger a before_script instead of the main script will enable
the tests to run again when building master.

Fixes the weird side effect from #384. /cc @dblock 