### PR TITLE
Support Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 cache: bundler
 
 rvm:
+  - 2.4.0
   - 2.3.0
   - 2.2.3
   - 2.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ scheme are considered to be bugs.
 ## [Unreleased][unreleased]
 
 * [#386](https://github.com/intridea/hashie/pull/386): Fix for #385: Make `deep_merge` always `deep_dup` nested hashes before merging them in so that there are no shared references between the two hashes being merged. - [@mltsy](https://github.com/mltsy).
+* [#389](https://github.com/intridea/hashie/pull/389): Support Ruby 2.4.0 - [@camelmasa](https://github.com/camelmasa).
 
 [3.4.7]: https://github.com/intridea/hashie/compare/v3.4.6...master
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ end
 
 group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
-  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.4.0')
+  require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
+  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >= Hashie::Extensions::RubyVersion.new('2.4.0')
     gem 'activesupport', '~> 5.x', require: false
   else
     gem 'activesupport', '~> 4.x', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,11 @@ end
 
 group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
-  gem 'activesupport', '~> 4.x', require: false
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.4.0')
+    gem 'activesupport', '~> 5.x', require: false
+  else
+    gem 'activesupport', '~> 4.x', require: false
+  end
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
   gem 'rspec-core', '~> 3.1.7'
   gem 'danger-changelog', '~> 0.1.0', require: false

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -12,10 +12,14 @@ module Hashie
         Symbol     => :to_sym
       }
 
-      ABSTRACT_CORE_TYPES = {
-        Integer => [Fixnum, Bignum],
-        Numeric => [Fixnum, Bignum, Float, Complex, Rational]
-      }
+      ABSTRACT_CORE_TYPES = if RubyVersion.new(RUBY_VERSION) >= RubyVersion.new('2.4.0')
+                              { Numeric => [Integer, Float, Complex, Rational] }
+                            else
+                              {
+                                Integer => [Fixnum, Bignum],
+                                Numeric => [Fixnum, Bignum, Float, Complex, Rational]
+                              }
+                            end
 
       def self.included(base)
         base.send :include, InstanceMethods

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -558,8 +558,14 @@ describe Hashie::Extensions::Coercion do
       end
 
       it 'raises a CoercionError when coercion is not possible' do
-        subject.coerce_value Fixnum, Symbol
-        expect { instance[:hi] = 1 }.to raise_error(Hashie::CoercionError, /Cannot coerce property :hi from Fixnum to Symbol/)
+        type = if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >= Hashie::Extensions::RubyVersion.new('2.4.0')
+                 Integer
+               else
+                 Fixnum
+               end
+
+        subject.coerce_value type, Symbol
+        expect { instance[:hi] = 1 }.to raise_error(Hashie::CoercionError, /Cannot coerce property :hi from #{type} to Symbol/)
       end
 
       it 'coerces Integer to String' do


### PR DESCRIPTION
I'd like to use this gem with Ruby 2.4.0.
I couldn't `bundle install` using Ruby 2.4.0 because activesupport 4.x  is depending old `json` gem.