### PR TITLE
Since hashie/mash can be required alone, require its dependencies

### DIFF
--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -1,22 +1,6 @@
-require 'logger'
 require 'hashie/version'
 
 module Hashie
-  # The logger that Hashie uses for reporting errors.
-  #
-  # @return [Logger]
-  def self.logger
-    @logger ||= Logger.new(STDOUT)
-  end
-
-  # Sets the logger that Hashie uses for reporting errors.
-  #
-  # @param logger [Logger] The logger to set as Hashie's logger.
-  # @return [void]
-  def self.logger=(logger)
-    @logger = logger
-  end
-
   autoload :Clash,              'hashie/clash'
   autoload :Dash,               'hashie/dash'
   autoload :Hash,               'hashie/hash'

--- a/lib/hashie/array.rb
+++ b/lib/hashie/array.rb
@@ -1,4 +1,5 @@
 require 'hashie/extensions/array/pretty_inspect'
+require 'hashie/extensions/ruby_version'
 require 'hashie/extensions/ruby_version_check'
 
 module Hashie

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -1,7 +1,24 @@
+require 'logger'
+require 'hashie/utils'
 require 'hashie/hash'
 require 'hashie/array'
 
 module Hashie
+  # The logger that Hashie uses for reporting errors.
+  #
+  # @return [Logger]
+  def self.logger
+    @logger ||= Logger.new(STDOUT)
+  end
+
+  # Sets the logger that Hashie uses for reporting errors.
+  #
+  # @param logger [Logger] The logger to set as Hashie's logger.
+  # @return [void]
+  def self.logger=(logger)
+    @logger = logger
+  end
+
   # Mash allows you to create pseudo-objects that have method-like
   # accessors for hash keys. This is useful for such implementations
   # as an API-accessing library that wants to fake robust objects


### PR DESCRIPTION
Thanks for considering the fix here.
Just requiring mash is not optimal.
I did put a PR in to omniauth to request they require 'hashie' at the root level.

This is my suggestions for minimal changes.
If you prefer, I can move the logging into its own module (along with utils) - wasn't sure how much of a change you wanted.

Let me know how you would prefer to proceed.

---

To reproduce I used the following:

**before:**

```
be irb
require 'omniauth-google-oauth2'

NameError: uninitialized constant Hashie::Extensions::RubyVersionCheck::ClassMethods::RubyVersion
```

**after:**

```
be irb
require 'omniauth-google-oauth2'
puts "yay"
# => "yay"
```

----

Fixes #391

### require ruby_version

ruby_version_check accesses ruby_version.

Since array is one of the first files required, this is sufficient to
resolve this class.

### move logger

The only component that uses logger is mash. Move the logger to
where it is used.