### PR TITLE
Bring integration tests into main test harness

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 AllCops:
+  Include:
+    - Guardfile
+    - Rakefile
   Exclude:
     - .bundle/**/*
     - bin/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ scheme are considered to be bugs.
 
 ### Miscellanous
 
-* Your contribution here.
+* [#397](https://github.com/intridea/hashie/pull/397): Add the integration specs harness into the main test tasks - [@michaelherold](https://github.com/michaelherold).
 
 ## [3.5.1] - 2017-01-31
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem 'rubocop', '0.34.2'
   gem 'guard', '~> 2.6.1'
   gem 'guard-rspec', '~> 4.3.1', require: false
+  gem 'guard-yield', '~> 0.1.0', require: false
 end
 
 group :test do

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,21 @@
-guard 'rspec', all_on_start: false, cmd: 'bundle exec rspec' do
-  watch(/^spec\/.+_spec\.rb/)
-  watch(/^lib\/(.+)\.rb/) { |m| "spec/#{m[1]}_spec.rb" }
+require_relative 'spec/support/integration_specs'
+
+run_all = lambda do |*|
+  Compat::UI.info('Running all integration tests', reset: true)
+  run_all_integration_specs(logger: ->(msg) { Compat::UI.info(msg) })
+end
+
+guard 'rspec', all_on_start: false, cmd: 'bundle exec rspec', run_all: { cmd: 'bundle exec rspec --exclude-pattern "spec/integration/**/*_spec.rb"' } do
+  watch(%r{^spec(?!/integration)/.+_spec\.rb})
+  watch(%r{^lib/(.+)\.rb}) { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { 'spec' }
+end
+
+guard :yield, run_all: run_all do
+  watch(%r{^lib/(.+)\.rb}) { run_all.call }
+  watch(%r{^spec/integration/(?<integration>.*)/.+_spec\.rb}) do |file, integration|
+    Compat::UI.info(%(Running "#{integration}" integration test), reset: true)
+    system(integration_command(integration, 'bundle --quiet'))
+    system(integration_command(integration, "bundle exec rspec #{file}"))
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,20 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-task default: [:rubocop, :spec]
+require_relative 'spec/support/integration_specs'
+task :integration_specs do
+  next if ENV['CI']
+  status_codes = []
+  handler = lambda do |status_code|
+    status_codes << status_code unless status_code.zero?
+  end
+
+  run_all_integration_specs(handler: handler, logger: ->(msg) { puts msg })
+
+  if status_codes.any?
+    $stderr.puts "#{status_codes.size} integration test(s) failed"
+    exit status_codes.last
+  end
+end
+
+task default: [:rubocop, :spec, :integration_specs]

--- a/spec/integration/omniauth/integration_spec.rb
+++ b/spec/integration/omniauth/integration_spec.rb
@@ -6,7 +6,7 @@ require 'sinatra'
 require 'omniauth'
 
 class MyApplication < Sinatra::Base
-  use Rack::Session::Cookie
+  use Rack::Session::Cookie, secret: 'hashie integration tests'
   use OmniAuth::Strategies::Developer
 
   get '/' do

--- a/spec/support/integration_specs.rb
+++ b/spec/support/integration_specs.rb
@@ -1,0 +1,36 @@
+# Generates the bundle command for running an integration test
+#
+# @param [String] integration the integration folder to run
+# @param [String] command the command to run
+# @return [String]
+def integration_command(integration, command)
+  "#{integration_gemfile(integration)} #{command}"
+end
+
+# Generates the Gemfile for an integration
+#
+# @param [String] integration the integration test name
+# @return [String]
+def integration_gemfile(integration)
+  "BUNDLE_GEMFILE=#{integration_path(integration)}/Gemfile"
+end
+
+# Generates the path to the integration
+#
+# @param [String] integration the integration test name
+# @return [String]
+def integration_path(integration)
+  "spec/integration/#{integration}"
+end
+
+# Runs all integration specs in their own environment
+def run_all_integration_specs(handler: ->(_code) {}, logger: ->(_msg) {})
+  Dir['spec/integration/*']
+    .map { |directory| directory.split('/').last }
+    .each do |integration|
+      logger.call(%(Running "#{integration}" integration spec))
+      system(integration_command(integration, 'bundle --quiet'))
+      system(integration_command(integration, "bundle exec rspec #{integration_path(integration)}"))
+      handler.call($CHILD_STATUS.exitstatus)
+    end
+end


### PR DESCRIPTION
We have a nice integration spec harness, so let's make sure we use it
when we're working on the gem. I'm making the following changes:

* Make `bundle exec rake` run integration specs, except on Travis.
* Silence a warning in the OmniAuth integration spec that has nothing to
  do with Hashie.
* Make Guard run integration specs when appropriate. Now, when you run
  all tasks you will run integration specs. Also, if you modify an
  integration spec, it will run. Lastly, if you modify anything in `lib`
  the integration specs will run.
* Keeps the extra Travis build that only runs integration specs. Travis
  didn't like the Rake task that included it and there's extra signal by
  doing it this way anyway.
