### PR TITLE
Fix passing Pathname object to Hashie::Mesh.load()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ scheme are considered to be bugs.
 ### Fixed
 
 * [#396](https://github.com/intridea/hashie/pull/396): Fix for specs in #381: Incorrect use of shared context meant example was not being run - [@biinari](https://github.com/biinari).
+* [#399](https://github.com/intridea/hashie/pull/399): Fix passing Pathname object to Hashie::Mesh.load() - [@albb0920](https://github.com/albb0920).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -134,9 +134,10 @@ module Hashie
     # a string before it is set, and Hashes will be converted
     # into Mashes for nesting purposes.
     def custom_writer(key, value, convert = true) #:nodoc:
-      key_as_symbol = key.to_sym
+      key_as_symbol = (key = convert_key(key)).to_sym
+
       log_built_in_message(key_as_symbol) if methods.include?(key_as_symbol)
-      regular_writer(convert_key(key), convert ? convert_value(value) : value)
+      regular_writer(key, convert ? convert_value(value) : value)
     end
 
     alias_method :[], :custom_reader

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -632,6 +632,20 @@ describe Hashie::Mash do
       end
     end
 
+    context 'if the file is passed as Pathname' do
+      require 'pathname'
+      let(:path) { Pathname.new('database.yml') }
+
+      before do
+        expect(File).to receive(:file?).with(path).and_return(true)
+        expect(parser).to receive(:perform).with(path).and_return(config)
+      end
+
+      it 'return a Mash from a file' do
+        expect(subject.production.foo).to eq config['production']['foo']
+      end
+    end
+
     describe 'results are cached' do
       let(:parser) { double(:parser) }
 


### PR DESCRIPTION
As mentioned in issue #398

I'm not sure making this into one line is acceptable in this project.
RoboCop will complain too many lines for mash.rb if I but it into two lines.