### PR TITLE
Fix loading of Hashie.logger and set it to Rails.logger when in Rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ coverage
 rdoc
 pkg
 *.gem
+*.log
 .bundle
 .rvmrc
 Gemfile.lock
+log/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ scheme are considered to be bugs.
 ### Added
 
 * [#395](https://github.com/intridea/hashie/pull/395): Add the ability to disable warnings in Mash subclasses - [@michaelherold](https://github.com/michaelherold).
+* [#400](https://github.com/intridea/hashie/pull/400): Fix Hashie.logger load and set the Hashie logger to the Rails logger in a Rails environment - [@michaelherold](https://github.com/michaelherold).
 
 ### Changed
 

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -1,8 +1,7 @@
-require 'logger'
+require 'hashie/logger'
 require 'hashie/version'
 
 module Hashie
-  autoload :Logger,             'hashie/logger'
   autoload :Clash,              'hashie/clash'
   autoload :Dash,               'hashie/dash'
   autoload :Hash,               'hashie/hash'

--- a/lib/hashie/logger.rb
+++ b/lib/hashie/logger.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module Hashie
   # The logger that Hashie uses for reporting errors.
   #

--- a/lib/hashie/logger.rb
+++ b/lib/hashie/logger.rb
@@ -5,7 +5,12 @@ module Hashie
   #
   # @return [Logger]
   def self.logger
-    @logger ||= Logger.new(STDOUT)
+    @logger ||=
+      if defined?(::Rails)
+        Rails.logger
+      else
+        Logger.new(STDOUT)
+      end
   end
 
   # Sets the logger that Hashie uses for reporting errors.

--- a/spec/integration/rails/.rspec
+++ b/spec/integration/rails/.rspec
@@ -1,0 +1,3 @@
+--colour
+--format=documentation
+--pattern=*_spec.rb

--- a/spec/integration/rails/Gemfile
+++ b/spec/integration/rails/Gemfile
@@ -1,0 +1,5 @@
+source 'http://rubygems.org'
+
+gem 'hashie', path: '../../..'
+gem 'rails'
+gem 'rspec', '~> 3.5.0'

--- a/spec/integration/rails/integration_spec.rb
+++ b/spec/integration/rails/integration_spec.rb
@@ -1,0 +1,66 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'rspec/core'
+require 'rails'
+require 'rails/all'
+require 'action_view/testing/resolvers'
+
+module RailsApp
+  class Application < ::Rails::Application
+    config.action_dispatch.show_exceptions            = false
+    config.active_support.deprecation                 = :stderr
+    config.eager_load                                 = false
+    config.root                                       = __dir__
+    config.secret_key_base                            = 'hashieintegrationtest'
+
+    routes.append do
+      get '/' => 'application#index'
+    end
+
+    config.assets.paths << File.join(__dir__, 'assets/javascripts')
+    config.assets.debug = true
+  end
+end
+
+LAYOUT = <<-HTML
+<!DOCTYPE html>
+<html>
+<head>
+  <title>TestApp</title>
+  <%= stylesheet_link_tag    "application", :media => "all" %>
+  <%= javascript_include_tag "application" %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+<%= yield %>
+</body>
+</html>
+HTML
+
+INDEX = <<-HTML
+<h1>Hello, world!</h1>
+HTML
+
+class ApplicationController < ActionController::Base
+  include Rails.application.routes.url_helpers
+
+  layout 'application'
+
+  self.view_paths = [ActionView::FixtureResolver.new(
+    'layouts/application.html.erb'         => LAYOUT,
+    'application/index.html.erb'           => INDEX
+  )]
+
+  def index
+  end
+end
+
+RailsApp::Application.initialize!
+
+require 'hashie'
+
+RSpec.describe 'the Hashie logger' do
+  it 'is set to the Rails logger' do
+    expect(Hashie.logger).to eq(Rails.logger)
+  end
+end


### PR DESCRIPTION
The auto-load is never triggered because there is no `Hashie::Logger`
constant to trigger it. We need to `require` the file in the top level
`hashie.rb` and anywhere else that uses it (in case someone just loads a
single file).

At the moment, this is only used in Mash, so we're covered.

In addition, try to be smarter about the default logger by setting it to the
Rails logger when we're in a Rails environment.