### PR TITLE
Ensure Railties available when loading Railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ scheme are considered to be bugs.
 
 ## [Unreleased][unreleased]
 
+* [#409](https://github.com/intridea/hashie/pull/409): Fixed Railtie detection for projects where Rails is defined but Railties are not availble - [@CallumD](https://github.com/callumd).
+
 [unreleased]: https://github.com/intridea/hashie/compare/v3.5.3...master
 
 ### Added

--- a/lib/hashie/railtie.rb
+++ b/lib/hashie/railtie.rb
@@ -1,10 +1,14 @@
-require 'rails/railtie'
+begin
+  require 'rails/railtie'
 
-module Hashie
-  class Railtie < Rails::Railtie
-    # Set the Hashie.logger to use Rails.logger when used with rails.
-    initializer 'hashie.configure_logger', after: 'initialize_logger' do
-      Hashie.logger = Rails.logger
+  module Hashie
+    class Railtie < Rails::Railtie
+      # Set the Hashie.logger to use Rails.logger when used with rails.
+      initializer 'hashie.configure_logger', after: 'initialize_logger' do
+        Hashie.logger = Rails.logger
+      end
     end
   end
+rescue LoadError => e
+  Hashie.logger.info("Hashie skipping railtie as #{e.message}")
 end

--- a/spec/integration/rails-without-dependency/.rspec
+++ b/spec/integration/rails-without-dependency/.rspec
@@ -1,0 +1,3 @@
+--colour
+--format=documentation
+--pattern=*_spec.rb

--- a/spec/integration/rails-without-dependency/Gemfile
+++ b/spec/integration/rails-without-dependency/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+gem 'hashie', path: '../../..'
+gem 'rspec', '~> 3.5.0'

--- a/spec/integration/rails-without-dependency/integration_spec.rb
+++ b/spec/integration/rails-without-dependency/integration_spec.rb
@@ -1,0 +1,15 @@
+require 'rspec/core'
+
+RSpec.describe 'partial-rails' do
+  context 'when Rails constant is present but the railties are not' do
+    before(:all) do
+      class Rails
+        # A class about railways
+      end
+    end
+
+    it 'does not raise an exception when we require hashie' do
+      expect { require 'hashie' }.not_to raise_exception(LoadError)
+    end
+  end
+end


### PR DESCRIPTION
In some circumstances when a project has the Rails constant defined we
may still not be able to require the rails/railtie dependency. Before this
change this would raise an exception. This change seeks to add better
detection of the railtie dependency and add logging that this dependency
is missing but still allow execution to continue.