### PR TITLE
Fix a performance regression due to logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ scheme are considered to be bugs.
 
 ## [Unreleased][unreleased]
 
-* [#409](https://github.com/intridea/hashie/pull/409): Fixed Railtie detection for projects where Rails is defined but Railties are not availble - [@CallumD](https://github.com/callumd).
-
 [unreleased]: https://github.com/intridea/hashie/compare/v3.5.3...master
 
 ### Added
@@ -30,6 +28,8 @@ scheme are considered to be bugs.
 
 ### Fixed
 
+* [#409](https://github.com/intridea/hashie/pull/409): Fixed Railtie detection for projects where Rails is defined but Railties are not availble - [@CallumD](https://github.com/callumd).
+* [#411](https://github.com/intridea/hashie/pull/411): Fixed a performance regression from 3.4.3 that caused a 10x slowdown in OmniAuth - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -145,7 +145,7 @@ module Hashie
     def custom_writer(key, value, convert = true) #:nodoc:
       key_as_symbol = (key = convert_key(key)).to_sym
 
-      log_built_in_message(key_as_symbol) if methods.include?(key_as_symbol)
+      log_built_in_message(key_as_symbol) if respond_to?(key_as_symbol)
       regular_writer(key, convert ? convert_value(value) : value)
     end
 


### PR DESCRIPTION
By switching to `#respond_to?` we make the lookup of method collisions
a lot faster while retaining the ability to report on them.

Closes #410