### PR TITLE
Fix "@disable_warnings" spec warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ scheme are considered to be bugs.
 ### Miscellaneous
 
 * [#416](https://github.com/intridea/hashie/pull/416): Fix `warning: instance variable @disable_warnings not initialized` - [@axfcampos](https://github.com/axfcampos).
+* Your contribution here.
 
 ## [3.5.5] - 2017-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ scheme are considered to be bugs.
 
 ### Miscellaneous
 
-* Your contribution here.
+* Fix "warning: instance variable @disable_warnings not initialized" - [@axfcampos](https://github.com/axfcampos)
 
 ## [3.5.5] - 2017-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ scheme are considered to be bugs.
 
 ### Miscellaneous
 
-* Fix "warning: instance variable @disable_warnings not initialized" - [@axfcampos](https://github.com/axfcampos)
+* [#416](https://github.com/intridea/hashie/pull/416): Fix `warning: instance variable @disable_warnings not initialized` - [@axfcampos](https://github.com/axfcampos).
 
 ## [3.5.5] - 2017-02-24
 

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -83,7 +83,7 @@ module Hashie
     # @api semipublic
     # @return [Boolean]
     def self.disable_warnings?
-      !!(defined?(@disable_warnings) && @disable_warnings)
+      @disable_warnings ||= false
     end
 
     # Inheritance hook that sets class configuration when inherited.

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -83,7 +83,7 @@ module Hashie
     # @api semipublic
     # @return [Boolean]
     def self.disable_warnings?
-      !!@disable_warnings
+      !!(defined?(@disable_warnings) && @disable_warnings)
     end
 
     # Inheritance hook that sets class configuration when inherited.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,4 +19,5 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expect|
     expect.syntax = :expect
   end
+  config.warnings = true
 end


### PR DESCRIPTION
When running rspec specs on the ruby-grape project with warnings enabled
this warning is printed hundreds of times.

This change fixes the warning.