### PR TITLE
Allow the dig method on StrictKeyAccess hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ scheme are considered to be bugs.
 ### Added
 
 * [#419](https://github.com/intridea/hashie/pull/419): Allow the dig method on StrictKeyAccess hashes - [@llimllib](https://github.com/llimllib)
-* Your contribution here.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ scheme are considered to be bugs.
 
 ### Added
 
-* [#419](https://github.com/intridea/hashie/pull/419): Added StrictKeyAccess#dig so you can dig into StrictKeyAccess hashes - [@llimllib](https://github.com/llimllib)
+* [#419](https://github.com/intridea/hashie/pull/419): Allow the dig method on StrictKeyAccess hashes - [@llimllib](https://github.com/llimllib)
 * Your contribution here.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ scheme are considered to be bugs.
 
 ### Added
 
-* [#419](https://github.com/intridea/hashie/pull/419): Allow the dig method on StrictKeyAccess hashes - [@llimllib](https://github.com/llimllib)
+* [#419](https://github.com/intridea/hashie/pull/419): Allow the dig method on StrictKeyAccess hashes - [@llimllib](https://github.com/llimllib).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ scheme are considered to be bugs.
 
 ### Added
 
+* [#419](https://github.com/intridea/hashie/pull/419): Added StrictKeyAccess#dig so you can dig into StrictKeyAccess hashes - [@llimllib](https://github.com/llimllib)
 * Your contribution here.
 
 ### Changed

--- a/lib/hashie/extensions/strict_key_access.rb
+++ b/lib/hashie/extensions/strict_key_access.rb
@@ -79,7 +79,7 @@ module Hashie
           if keys.empty?
             value
           else
-            value.dig(keys) if keys.respond_to? 'dig'
+            value.dig(*keys) if value.respond_to? 'dig'
           end
         end
       end

--- a/lib/hashie/extensions/strict_key_access.rb
+++ b/lib/hashie/extensions/strict_key_access.rb
@@ -79,7 +79,7 @@ module Hashie
           if keys.empty?
             value
           else
-            value.dig(keys) if keys.responds_to? 'dig'
+            value.dig(keys) if keys.respond_to? 'dig'
           end
         end
       end

--- a/lib/hashie/extensions/strict_key_access.rb
+++ b/lib/hashie/extensions/strict_key_access.rb
@@ -79,11 +79,7 @@ module Hashie
           if keys.empty?
             value
           else
-            if keys.responds_to? "dig"
-              value.dig keys
-            else
-              nil
-            end
+            value.dig(keys) if keys.responds_to? 'dig'
           end
         end
       end

--- a/lib/hashie/extensions/strict_key_access.rb
+++ b/lib/hashie/extensions/strict_key_access.rb
@@ -69,6 +69,24 @@ module Hashie
           result
         end
       end
+
+      def dig(*keys)
+        value = fetch(keys.shift, nil)
+
+        if value.nil?
+          nil
+        else
+          if keys.empty?
+            value
+          else
+            if keys.responds_to? "dig"
+              value.dig keys
+            else
+              nil
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/hashie/extensions/strict_key_access_spec.rb
+++ b/spec/hashie/extensions/strict_key_access_spec.rb
@@ -23,6 +23,11 @@ describe Hashie::Extensions::StrictKeyAccess do
         expect(instance.key(valid_value)).to eq valid_key
       end
     end
+    context 'dig' do
+      it('returns value') do
+        expect(instance.dig(valid_key)).to eq valid_value
+      end
+    end
   end
   shared_examples_for 'StrictKeyAccess with invalid key' do |options = {}|
     before { pending_for(options[:pending]) } if options[:pending]
@@ -37,6 +42,11 @@ describe Hashie::Extensions::StrictKeyAccess do
         # Formatting of the error message does not vary here because raised by StrictKeyAccess
         expect { instance.key(invalid_value) }.to raise_error KeyError,
                                                               %(key not found with value of #{invalid_value.inspect})
+      end
+    end
+    context 'dig' do
+      it('returns nil') do
+        expect(instance.dig(invalid_value)).to be_nil
       end
     end
   end

--- a/spec/hashie/extensions/strict_key_access_spec.rb
+++ b/spec/hashie/extensions/strict_key_access_spec.rb
@@ -117,4 +117,20 @@ describe Hashie::Extensions::StrictKeyAccess do
     it_behaves_like 'StrictKeyAccess with invalid key', pending: { engine: 'rbx' }
     it_behaves_like 'StrictKeyAccess raises KeyError instead of allowing defaults'
   end
+
+  context '.dig' do
+    let(:instance) { StrictKeyAccessHash[{ symphony: StrictKeyAccessHash[{ of: 'destruction' }] }] }
+
+    it 'returns nested values' do
+      expect(instance.dig(:symphony, :of)).to eq 'destruction'
+    end
+
+    it 'returns nil on top-level keys that don\'t exist' do
+      expect(instance.dig(:metallica)).to eq nil
+    end
+
+    it 'returns nil on nested keys that don\'t exist' do
+      expect(instance.dig(:symphony, :london)).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you create a Hash with StrictKeyAccess mixed in, then you do
`some_strict_hash.dig 'alpha', 'beta'`, you will get a `DefaultError`
because ruby 2.4.0 tries to set the default somewhere in the dig mechanism
(it's not actually clear to me where, I looked at the source briefly).

This patch allows dig to work in a StrictKeyAccess hash just as it does
in a default hash.

My use case for this patch is that I want to have a hash that raises KeyError
by default on `[]` access for a key that does not exist, but I also want to
be able to explicitly allow `nil` when I use `dig`. In my particular case,
I've also mixed in `DeepFetch`, so I can use `deep_fetch` to distinguish
cases where I want to allow `nil` from cases where I don't.