### PR TITLE
Removed boilerplate text from changelog for 3.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ scheme are considered to be bugs.
 ### Miscellaneous
 
 * [#416](https://github.com/intridea/hashie/pull/416): Fix `warning: instance variable @disable_warnings not initialized` - [@axfcampos](https://github.com/axfcampos).
-* Your contribution here.
 
 ## [3.5.5] - 2017-02-24
 


### PR DESCRIPTION
Removed _Your contribution here._ in entry for release 3.5.6.