### PR TITLE
Fix Hashie::Rash randomly losing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ scheme are considered to be bugs.
 
 ### Fixed
 
+[#430](https://github.com/intridea/hashie/pull/430): Fix Hashie::Rash randomly losing items - [@Antti](https://github.com/Antti)
+
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/rash.rb
+++ b/lib/hashie/rash.rb
@@ -136,7 +136,7 @@ module Hashie
 
     def optimize_if_necessary!
       return unless (@lookups += 1) >= @optimize_every
-      @regexes = @regex_counts.sort_by { |_, count| -count }.map { |regex, _| regex }
+      @regexes = @regexes.sort_by { |regex| -@regex_counts[regex] }
       @lookups = 0
     end
   end

--- a/spec/hashie/rash_spec.rb
+++ b/spec/hashie/rash_spec.rb
@@ -74,4 +74,10 @@ describe Hashie::Rash do
     expect(subject.respond_to?(:to_a)).to be true
     expect(subject.methods).to_not include(:to_a)
   end
+
+  it 'does not lose keys' do
+    subject.optimize_every = 1
+    expect(subject['hello']).to eq('hello')
+    expect(subject['world']).to eq('world')
+  end
 end


### PR DESCRIPTION
[Here](https://github.com/intridea/hashie/blob/32514df06550e21dc47d5c989ff6a90ef0c9b9fa/lib/hashie/rash.rb#L139) it replaces content of the `@regexes` with the new array, based on the count table, which is initially empty and then is filled up with the values after a lookup.
So if there was no lookup for a given regex in 500 lookup cycles, the regex will not get into the table and will be lost after the next optimisation.
