### PR TITLE
Add documentation for Mash subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ scheme are considered to be bugs.
 
 ### Miscellaneous
 
+* [#434](https://github.com/intridea/hashie/pull/434): Add documentation around Mash sub-Hashes - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## [3.5.7] - 2017-12-19


### PR DESCRIPTION
The behavior of Mash subclasses around the wrapping of inner sub-Hashes can be
confusing, so we should have some documentation around it. This captures the
process of subclasses wrapping their sub-Hashes in a guided fashion.

Also, this reorganizes a bit of the Mash readme to group related topics together
under headlines.

Fixes #432