### PR TITLE
Propagate Mash `default_proc` to sub-Hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ scheme are considered to be bugs.
 
 ### Fixed
 
+* [#435](https://github.com/intridea/hashie/pull/435): Mash `default_proc`s are now propagated down to nested sub-Hashes - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -186,7 +186,7 @@ module Hashie
     alias_method :regular_dup, :dup
     # Duplicates the current mash as a new mash.
     def dup
-      self.class.new(self, default)
+      self.class.new(self, default, &default_proc)
     end
 
     alias_method :regular_key?, :key?

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -457,6 +457,13 @@ describe Hashie::Mash do
       expect(initial.test?).to be_truthy
     end
 
+    it 'allows propagation of a default block' do
+      h = Hashie::Mash.new { |mash, key| mash[key] = mash.class.new(&mash.default_proc) }
+      expect { h[:x][:y][:z] = :xyz }.not_to raise_error
+      expect(h.x.y.z).to eq(:xyz)
+      expect(h[:x][:y][:z]).to eq(:xyz)
+    end
+
     it 'allows assignment of an empty array in a default block' do
       initial = Hashie::Mash.new { |h, k| h[k] = [] }
       initial.hello << 100


### PR DESCRIPTION
In the case where you want to set deeply nested values through chained calls to
the `#[]` method or through method accessors (without using the bang methods),
you might set a `default_proc` on a Mash that recursively creates the key as you
access it. Previously, the `default_proc` was not being propagated down to
sub-Hashes because the way that `#dup` was written wasn't passing the
`default_proc` do the duplicated object.

Now, the `default_proc` is correctly being sent to the duplicated object, which
allows this pattern to work:

```ruby
h = Hashie::Mash.new { |mash, key| mash[key] = mash.class.new(&mash.default_proc) }
h.a.b.c = :xyz
h[:a][:b][:c] #=> :xyz
h[:x][:y][:z] = :abc
h.x.y.z #=> :abc
```

Fixes #208