### PR TITLE
Allow codependent Dash attributes to initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ scheme are considered to be bugs.
 
 * [#435](https://github.com/intridea/hashie/pull/435): Mash `default_proc`s are now propagated down to nested sub-Hashes - [@michaelherold](https://github.com/michaelherold).
 * [#436](https://github.com/intridea/hashie/pull/436): Ensure that `Hashie::Extensions::IndifferentAccess` injects itself after a non-destructive merge - [@michaelherold](https://github.com/michaelherold).
+* [#437](https://github.com/intridea/hashie/pull/437): Allow codependent properties to be set on Dash - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -160,7 +160,7 @@ module Hashie
     end
 
     def update_attributes!(attributes)
-      initialize_attributes(attributes)
+      update_attributes(attributes)
 
       self.class.defaults.each_pair do |prop, value|
         self[prop] = begin
@@ -175,9 +175,18 @@ module Hashie
     private
 
     def initialize_attributes(attributes)
+      return unless attributes
+
+      cleaned_attributes = attributes.reject { |_attr, value| value.nil? }
+      update_attributes(cleaned_attributes)
+    end
+
+    def update_attributes(attributes)
+      return unless attributes
+
       attributes.each_pair do |att, value|
         self[att] = value
-      end if attributes
+      end
     end
 
     def assert_property_exists!(property)

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -402,6 +402,31 @@ describe DashTest do
         expect(subject.count).to eq subject.class.defaults[:count]
       end
     end
+
+    context 'codependent attributes' do
+      let(:codependent) do
+        Class.new(Hashie::Dash) do
+          property :a, required: -> { b.nil? }, message: 'is required if b is not set.'
+          property :b, required: -> { a.nil? }, message: 'is required if a is not set.'
+        end
+      end
+
+      it 'does not raise an error when only the first property is set' do
+        expect { codependent.new(a: 'ant', b: nil) }.not_to raise_error
+      end
+
+      it 'does not raise an error when only the second property is set' do
+        expect { codependent.new(a: nil, b: 'bat') }.not_to raise_error
+      end
+
+      it 'does not raise an error when both properties are set' do
+        expect { codependent.new(a: 'ant', b: 'bat') }.not_to raise_error
+      end
+
+      it 'raises an error when neither property is set' do
+        expect { codependent.new(a: nil, b: nil) }.to raise_error(ArgumentError)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Definition: Codependent properties
A set of two or more properties who have "required" validations that are based
on each other.

Example:

```ruby
class OneOrMore < Hashie::Dash
  property :a, required: -> { b.nil? }
  property :b, required: -> { a.nil? }
end
```

When constructing a Dash via the merge initializer, codependent properties have
their "required" validation run too early when their values are set to `nil`,
which causes an `ArgumentError` to be raised in the case that the first property
is set to `nil`.

This is an order-dependence bug that is fixed by this commit. By pruning off
`nil` values only during initialization via the merge initializer, we can
prevent this problem from occurring for the case of `nil` values.

However, this is an indication of a larger problem with the architecture of
Dash. We should be setting all the properties before running the validations.
Rearchitecting this will be quite an undertaking.

Fixes #431