### PR TITLE
Fix: NameError (uninitialized constant Hashie::Extensions::Parsers::YamlErbParser::Pathname)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ scheme are considered to be bugs.
 * [#435](https://github.com/intridea/hashie/pull/435): Mash `default_proc`s are now propagated down to nested sub-Hashes - [@michaelherold](https://github.com/michaelherold).
 * [#436](https://github.com/intridea/hashie/pull/436): Ensure that `Hashie::Extensions::IndifferentAccess` injects itself after a non-destructive merge - [@michaelherold](https://github.com/michaelherold).
 * [#437](https://github.com/intridea/hashie/pull/437): Allow codependent properties to be set on Dash - [@michaelherold](https://github.com/michaelherold).
+* [#438](https://github.com/intridea/hashie/pull/438): Fix: `NameError (uninitialized constant Hashie::Extensions::Parsers::YamlErbParser::Pathname)` in `Hashie::Mash.load` - [@onk](https://github.com/onk).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/extensions/parsers/yaml_erb_parser.rb
+++ b/lib/hashie/extensions/parsers/yaml_erb_parser.rb
@@ -1,5 +1,7 @@
 require 'yaml'
 require 'erb'
+require 'pathname'
+
 module Hashie
   module Extensions
     module Parsers


### PR DESCRIPTION
`Hashie::Mash.load` require `Pathname` since v3.4.5.

see: bbafaded9d

```
irb(main):001:0> require "hashie"
=> true
irb(main):002:0> Hashie::Mash.load("foo.yml")
Traceback (most recent call last):
        6: from /opt/rubies/2.6.0-dev/bin/irb:11:in `<main>'
        5: from (irb):2
        4: from /Users/onaka/.gem/ruby/2.6.0/gems/hashie-3.5.7/lib/hashie/mash.rb:105:in `load'
        3: from /Users/onaka/.gem/ruby/2.6.0/gems/hashie-3.5.7/lib/hashie/extensions/parsers/yaml_erb_parser.rb:19:in `perform'
        2: from /Users/onaka/.gem/ruby/2.6.0/gems/hashie-3.5.7/lib/hashie/extensions/parsers/yaml_erb_parser.rb:19:in `new'
        1: from /Users/onaka/.gem/ruby/2.6.0/gems/hashie-3.5.7/lib/hashie/extensions/parsers/yaml_erb_parser.rb:9:in `initialize'
NameError (uninitialized constant Hashie::Extensions::Parsers::YamlErbParser::Pathname)
irb(main):003:0> require "pathname"
=> true
irb(main):004:0> Hashie::Mash.load("foo.yml")
=> #<Hashie::Mash bar="baz">
```