### PR TITLE
Add an integration spec for Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ scheme are considered to be bugs.
 ### Miscellaneous
 
 * [#434](https://github.com/intridea/hashie/pull/434): Add documentation around Mash sub-Hashes - [@michaelherold](https://github.com/michaelherold).
+* [#439](https://github.com/intridea/hashie/pull/439): Add an integration spec for Elasticsearch - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## [3.5.7] - 2017-12-19

--- a/spec/integration/elasticsearch/Gemfile
+++ b/spec/integration/elasticsearch/Gemfile
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gem 'elasticsearch-model'
+gem 'hashie', path: '../../..'
+gem 'rake'
+gem 'rspec', '~> 3.5.0'

--- a/spec/integration/elasticsearch/integration_spec.rb
+++ b/spec/integration/elasticsearch/integration_spec.rb
@@ -1,0 +1,40 @@
+require 'elasticsearch/model'
+require 'hashie'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expect|
+    expect.syntax = :expect
+  end
+end
+
+class MyModel < Hashie::Mash
+  include Elasticsearch::Model
+
+  disable_warnings
+
+  index_name 'model'
+  document_type 'model'
+end
+
+RSpec.describe 'elaasticsearch-model' do
+  # See https://github.com/intridea/hashie/issues/354#issuecomment-363306114
+  # for the reason why this doesn't work as you would expect
+  it 'raises an error when the model does has an id' do
+    object = MyModel.new
+    stub_elasticsearch_client
+
+    expect { object.__elasticsearch__.index_document }.to raise_error(NoMethodError)
+  end
+
+  it 'does not raise an error when the model has an id' do
+    object = MyModel.new(id: 123)
+    stub_elasticsearch_client
+
+    expect { object.__elasticsearch__.index_document }.not_to raise_error
+  end
+
+  def stub_elasticsearch_client
+    response = double('Response', body: '{}')
+    allow_any_instance_of(Elasticsearch::Transport::Client).to receive(:perform_request) { response }
+  end
+end


### PR DESCRIPTION
The Elasticsearch gems heavily integrate with Hashie. This leads people to want
to use a Mash as the backer for an Elasticsearch model, but the behavior is
different than they expect. By having this integration spec, we're covering two
things:

1. It might help ensure that we don't break the Elasticsearch ecosystem with
   changes in Hashie as has happened in the past.
2. It communicates some gotchas that happen with using a Mash as the backer for
   an Elasticsearch model.

Resolves #354 