### PR TITLE
Add MethodOverridingInitializer extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ scheme are considered to be bugs.
 
 ### Added
 
+* [#455](https://github.com/intridea/hashie/pull/455): Allow overriding methods when passing in a hash - [@lnestor](https://github.com/lnestor).
 * Your contribution here.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -243,6 +243,26 @@ overriding.zip   #=> 'a-dee-doo-dah'
 overriding.__zip #=> [[['zip', 'a-dee-doo-dah']]]
 ```
 
+### MethodOverridingInitializer
+
+The MethodOverridingInitializer extension will override hash methods if you pass in a normal hash to the constructor. It aliases any overridden method with two leading underscores. To include only this initializing functionality, you can include the single module `Hashie::Extensions::MethodOverridingInitializer`.
+
+```ruby
+class MyHash < Hash
+end
+
+class MyOverridingHash < Hash
+  include Hashie::Extensions::MethodOverridingInitializer
+end
+
+non_overriding = MyHash.new(zip: 'a-dee-doo-dah')
+non_overriding.zip #=> []
+
+overriding = MyOverridingHash.new(zip: 'a-dee-doo-dah')
+overriding.zip   #=> 'a-dee-doo-dah'
+overriding.__zip #=> [[['zip', 'a-dee-doo-dah']]]
+```
+
 ### IndifferentAccess
 
 This extension can be mixed in to your Hash subclass to allow you to use Strings or Symbols interchangeably as keys; similar to the `params` hash in Rails.

--- a/lib/hashie/extensions/method_access.rb
+++ b/lib/hashie/extensions/method_access.rb
@@ -158,6 +158,7 @@ module Hashie
     # to contained shared logic. This module aids in redefining existing hash methods.
     module RedefineMethod
       protected
+
       def method?(name)
         methods.map(&:to_s).include?(name)
       end
@@ -168,7 +169,6 @@ module Hashie
         eigenclass.__send__(:define_method, method_name, -> { self[method_name] })
       end
     end
-
 
     # MethodOverridingWriter gives you #key_name= shortcuts for
     # writing to your hash. It allows methods to be overridden by
@@ -231,7 +231,11 @@ module Hashie
     # underscores.
     module MethodAccessWithOverride
       def self.included(base)
-        [MethodReader, MethodOverridingWriter, MethodQuery, MethodOverridingInitializer].each do |mod|
+        Hashie.logger.info(
+          'MethodOverridingInitializer will be included in MethodAccessWithOverride' \
+          ' by default in Hashie version 4.0'
+        )
+        [MethodReader, MethodOverridingWriter, MethodQuery].each do |mod|
           base.send :include, mod
         end
       end

--- a/lib/hashie/version.rb
+++ b/lib/hashie/version.rb
@@ -1,3 +1,3 @@
 module Hashie
-  VERSION = '3.5.8'.freeze
+  VERSION = '3.6.0'.freeze
 end

--- a/spec/hashie/extensions/method_access_spec.rb
+++ b/spec/hashie/extensions/method_access_spec.rb
@@ -183,6 +183,50 @@ describe Hashie::Extensions::MethodAccessWithOverride do
   it 'includes all of the other method mixins' do
     klass = Class.new(Hash)
     klass.send :include, Hashie::Extensions::MethodAccessWithOverride
-    expect((klass.ancestors & [Hashie::Extensions::MethodReader, Hashie::Extensions::MethodOverridingWriter, Hashie::Extensions::MethodQuery]).size).to eq 3
+    expect((klass.ancestors &
+            [Hashie::Extensions::MethodReader,
+             Hashie::Extensions::MethodOverridingWriter,
+             Hashie::Extensions::MethodQuery,
+             Hashie::Extensions::MethodOverridingInitializer]
+           ).size).to eq 4
+  end
+end
+
+describe Hashie::Extensions::MethodOverridingInitializer do
+  class OverridingHash < Hash
+    include Hashie::Extensions::MethodOverridingInitializer
+  end
+
+  context 'when the key is a string' do
+    subject { OverridingHash.new('zip' => 'a-dee-doo-dah') }
+
+    it 'overrides the original method' do
+      expect(subject.zip).to eq 'a-dee-doo-dah'
+    end
+
+    it 'aliases the method with two leading underscores' do
+      expect(subject.__zip).to eq [[%w[zip a-dee-doo-dah]]]
+    end
+  end
+
+  context 'when the key is a symbol' do
+    subject { OverridingHash.new(zip: 'a-dee-doo-dah') }
+
+    it 'overrides the original method' do
+      expect(subject.zip).to eq 'a-dee-doo-dah'
+    end
+
+    it 'aliases the method with two leading underscores' do
+      expect(subject.__zip).to eq [[%w[zip a-dee-doo-dah]]]
+    end
+  end
+
+  context 'when the original hash has double keys' do
+    let(:original_hash) { { zip: 'a-dee-doo-dah', zip: 'a-dee-day' } } # rubocop:disable DuplicatedKey
+    subject { OverridingHash.new(original_hash) }
+
+    it 'returns the value respected by the original hash' do
+      expect(subject.zip).to eq original_hash[:zip]
+    end
   end
 end

--- a/spec/hashie/extensions/method_access_spec.rb
+++ b/spec/hashie/extensions/method_access_spec.rb
@@ -186,9 +186,8 @@ describe Hashie::Extensions::MethodAccessWithOverride do
     expect((klass.ancestors &
             [Hashie::Extensions::MethodReader,
              Hashie::Extensions::MethodOverridingWriter,
-             Hashie::Extensions::MethodQuery,
-             Hashie::Extensions::MethodOverridingInitializer]
-           ).size).to eq 4
+             Hashie::Extensions::MethodQuery]
+           ).size).to eq 3
   end
 end
 

--- a/spec/hashie/extensions/method_access_spec.rb
+++ b/spec/hashie/extensions/method_access_spec.rb
@@ -220,13 +220,4 @@ describe Hashie::Extensions::MethodOverridingInitializer do
       expect(subject.__zip).to eq [[%w[zip a-dee-doo-dah]]]
     end
   end
-
-  context 'when the original hash has double keys' do
-    let(:original_hash) { { zip: 'a-dee-doo-dah', zip: 'a-dee-day' } } # rubocop:disable DuplicatedKey
-    subject { OverridingHash.new(original_hash) }
-
-    it 'returns the value respected by the original hash' do
-      expect(subject.zip).to eq original_hash[:zip]
-    end
-  end
 end


### PR DESCRIPTION
### Describe the change
This PR adds a new extension - MethodOverridingInitializer. This extension allows existing hash methods to be overridden if a hash passed in to the constructor contains such keys. For example:
```ruby
class OverridingHash < Hash
  include Hashie::Extensions::MethodOverridingInitializer
end

hash = OverridingHash.new(zip: 'a-dee-doo-dah')
hash.zip #=> 'a-dee-doo-dah'
hash.__zip #=> [[[zip a-dee-doo-dah]]]
```

### Issue 
References #338 

### Design Decisions
I made this its own extension in case people want to restrict which methods can be overwritten. Using this extension only, they can pass in a hash of only the methods they want overwritten and prevent overwriting other methods.

### Possible Alternatives
This could be included in the extension MethodAccessWithOverride instead of being it's own extension.