### PR TITLE
 Use == instead of <= in build_coercion 

### DIFF
--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -162,7 +162,7 @@ module Hashie
             if type.class == ::Hash
               type, key_type, value_type = type.class, *type.first
               build_hash_coercion(type, key_type, value_type)
-            else # Enumerable but not Hash: Array, Set
+            else
               value_type = type.first
               type = type.class
               build_container_coercion(type, value_type)

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -159,7 +159,7 @@ module Hashie
 
         def build_coercion(type)
           if type.is_a? Enumerable
-            if type.class <= ::Hash
+            if type.class == ::Hash
               type, key_type, value_type = type.class, *type.first
               build_hash_coercion(type, key_type, value_type)
             else # Enumerable but not Hash: Array, Set


### PR DESCRIPTION
Unless  `<=` operator is overwritten (which, unless we have missed something, is not), to check if the type class is a Hash, it is more readable to use `==` than `<=`. It returns `false`/`true` instead of `nil`/`0`, but this doesn't make a different when using it in a condition. :bowtie: 

As the code is now self-explanatory, the comment can be removed. :wink: 

Co-authored-by: Ana María Martínez Gómez <ammartinez@suse.de>