### PR TITLE
Calls readers only when a key exists for Mash#update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ scheme are considered to be bugs.
 ### Fixed
 
 * [#459](https://github.com/intridea/hashie/pull/459): Fixed a regression in `Mash.load` that disallowed aliases - [@arekt](https://github.com/arekt) and [@michaelherold](https://github.com/michaelherold).
+* [#465](https://github.com/intridea/hashie/pull/465): Fixed `deep_update` to call any readers when a key exists - [@laertispappas](https://github.com/laertispappas).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -214,7 +214,7 @@ module Hashie
     def deep_update(other_hash, &blk)
       other_hash.each_pair do |k, v|
         key = convert_key(k)
-        if regular_reader(key).is_a?(Mash) && v.is_a?(::Hash)
+        if key?(key) && regular_reader(key).is_a?(Mash) && v.is_a?(::Hash)
           custom_reader(key).deep_update(v, &blk)
         else
           value = convert_value(v, true)

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -241,6 +241,15 @@ describe Hashie::Mash do
         expect(duped.details.address).to eq 'Nowhere road'
         expect(duped.details.state).to eq 'West Thoughtleby'
       end
+
+      it 'does not raise an exception when default_proc raises an error' do
+        hash = described_class.new(a: 1) { |_k, _v| raise('Should not be raise I') }
+        other_has = described_class.new(a: 2, b: 2) { |_k, _v| raise('Should not be raise II') }
+        expected_hash = described_class.new(a: 2, b: 2)
+
+        res = hash.merge(other_has)
+        expect(res).to eq(expected_hash)
+      end
     end
 
     describe 'shallow update' do


### PR DESCRIPTION
Addresses: https://github.com/intridea/hashie/issues/464

Checks if key is present in `deep_update` before calling any reader method. Calling a reader method will execute the default block and we now prevent it.