### PR TITLE
Enable load symbol class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ scheme are considered to be bugs.
 ### Added
 
 * [#323](https://github.com/intridea/hashie/pull/323): Added `Hashie::Extensions::Mash::DefineAccessors` - [@marshall-lee](https://github.com/marshall-lee).
+* [#473](https://github.com/intridea/hashie/pull/473): Enable load symbol class - [@riouruma](https://github.com/riouruma).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -582,6 +582,33 @@ mash = Mash.load('data/user.csv', parser: MyCustomCsvParser)
 mash[1] #=> { name: 'John', lastname: 'Doe' }
 ```
 
+`Mash.load` calls `YAML.safe_load(path)`, and the default allowed classes are:
+- TrueClass
+- FalseClass
+- NilClass
+- Numeric
+- String
+- Array 
+- Hash
+
+you can customize whitelist classes.
+
+```ruby
+# /lib/hashie/extensions/parser/yaml_erb_parser.rb
+ 
+def perform
+  template = ERB.new(@content)
+  template.filename = @file_path
+  YAML.safe_load template.result, whitelist_classes, [], true
+end
+
+private
+
+def whitelist_classes
+  %w[Symbol]
+end
+```
+  
 ### Mash Extension: KeepOriginalKeys
 
 This extension can be mixed into a Mash to keep the form of any keys passed directly into the Mash. By default, Mash converts keys to strings to give indifferent access. This extension still allows indifferent access, but keeps the form of the keys to eliminate confusion when you're not expecting the keys to change.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,38 @@
 Upgrading Hashie
 ================
 
+### Upgrading to 3.6.1
+
+#### Enable load Symbol class 
+
+If you need to allow loading classes in `Hashie::Mash.load(path)`, you can customize 
+whitelist classes.  
+By default, `safe_load` only allows the following classes:
+
+- TrueClass
+- FalseClass
+- NilClass
+- Numeric
+- String
+- Array 
+- Hash
+
+```ruby
+# /lib/hashie/extensions/parser/yaml_erb_parser.rb
+ 
+def perform
+  template = ERB.new(@content)
+  template.filename = @file_path
+  YAML.safe_load template.result, whitelist_classes, [], true
+end
+
+private
+
+def whitelist_classes
+  %w[Symbol]
+end
+```
+
 ### Upgrading to 3.5.2
 
 #### Disable logging in Mash subclasses

--- a/lib/hashie/extensions/parsers/yaml_erb_parser.rb
+++ b/lib/hashie/extensions/parsers/yaml_erb_parser.rb
@@ -14,7 +14,7 @@ module Hashie
         def perform
           template = ERB.new(@content)
           template.filename = @file_path
-          YAML.safe_load template.result, [], [], true
+          YAML.safe_load template.result, [Symbol], [], true
         end
 
         def self.perform(file_path)

--- a/lib/hashie/extensions/parsers/yaml_erb_parser.rb
+++ b/lib/hashie/extensions/parsers/yaml_erb_parser.rb
@@ -14,11 +14,17 @@ module Hashie
         def perform
           template = ERB.new(@content)
           template.filename = @file_path
-          YAML.safe_load template.result, [Symbol], [], true
+          YAML.safe_load template.result, whitelist_classes, [], true
         end
 
         def self.perform(file_path)
           new(file_path).perform
+        end
+
+        private
+
+        def whitelist_classes
+          %w(Symbol)
         end
       end
     end

--- a/lib/hashie/extensions/parsers/yaml_erb_parser.rb
+++ b/lib/hashie/extensions/parsers/yaml_erb_parser.rb
@@ -24,7 +24,7 @@ module Hashie
         private
 
         def whitelist_classes
-          %w(Symbol)
+          %w[Symbol]
         end
       end
     end

--- a/spec/fixtures/yaml_with_symbols.yml
+++ b/spec/fixtures/yaml_with_symbols.yml
@@ -1,0 +1,18 @@
+:user_icon:
+  :record: profile_image_url
+  :path: users
+  :filename: icon
+  :quality: 60
+  :image_size:
+    :tmp:
+      :width: 100
+      :height: 100
+    :large:
+      :width: 200
+      :height: 200
+    :medium:
+      :width: 100
+      :height: 100
+    :small:
+      :width: 50
+      :height: 50

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -714,6 +714,13 @@ describe Hashie::Mash do
         expect(mash.company_a.accounts.admin.password).to eq('secret')
       end
     end
+
+    context 'when the file has symbols' do
+      it 'can use symbols and does not raise an error' do
+        mash = Hashie::Mash.load('spec/fixtures/yaml_with_symbols.yml')
+        expect(mash.user_icon.image_size.large.width).to eq(200)
+      end
+    end
   end
 
   describe '#to_module(mash_method_name)' do


### PR DESCRIPTION
# Problem
I got an error when `rails server` started.
```
from /Users/rails/project/vendor/bundle/ruby/2.6.0/bundler/gems/hashie/lib/hashie/mash.rb:110:in `load'
from /Users/rails/project/vendor/bundle/ruby/2.6.0/bundler/gems/hashie/lib/hashie/extensions/parsers/yaml_erb_parser.rb:21:in `perform'
from /Users/rails/project/vendor/bundle/ruby/2.6.0/bundler/gems/hashie/lib/hashie/extensions/parsers/yaml_erb_parser.rb:17:in `perform'
・・・
/Users/.rbenv/versions/2.6.2/lib/ruby/2.6.0/psych/class_loader.rb:97:in `find': Tried to load unspecified class: Symbol (Psych::DisallowedClass)
``` 

We need to allow Symbol class on `YAML.safe_load` .

# Related issue
https://github.com/intridea/hashie/issues/458