### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ scheme are considered to be bugs.
 
 [semver]: http://semver.org/spec/v2.0.0.html
 
-## [Unreleased][unreleased]
+## [3.7.0] - 2019-08-16
 
-[unreleased]: https://github.com/intridea/hashie/compare/v3.6.0...master
+[3.7.0]: https://github.com/intridea/hashie/compare/v3.6.0..v3.7.0
 
 ### Added
 
@@ -16,33 +16,15 @@ scheme are considered to be bugs.
 * [#474](https://github.com/intridea/hashie/pull/474): Expose `YAML#safe_load` options in `Mash#load` - [@riouruma](https://github.com/riouruma), [@dblock](https://github.com/dblock).
 * [#478](https://github.com/intridea/hashie/pull/478): Added optional array parameter to `Hashie::Mash.disable_warnings` - [@bobbymcwho](https://github.com/bobbymcwho).
 
-### Changed
-
-* Your contribution here.
-
-### Deprecated
-
-* Your contribution here.
-
-### Removed
-
-* Your contribution here.
-
 ### Fixed
 
 * [#459](https://github.com/intridea/hashie/pull/459): Fixed a regression in `Mash.load` that disallowed aliases - [@arekt](https://github.com/arekt) and [@michaelherold](https://github.com/michaelherold).
 * [#465](https://github.com/intridea/hashie/pull/465): Fixed `deep_update` to call any readers when a key exists - [@laertispappas](https://github.com/laertispappas).
-* Your contribution here.
-
-### Security
-
-* Your contribution here.
 
 ### Miscellaneous
 
 * [#465](https://github.com/intridea/hashie/pull/465): Clean up our RuboCop configuration and fix the outstanding line length violations. This involved some minor refactoring on `Hashie::Extensions::Coercion`, `Hashie::Extensions::Dash::IndifferentAccess`, `Hashie::Extensions::DeepLocate`, `Hashie::Extensions::Mash::SafeAssignment`, and `Hashie::Hash`, but none that were detectable via the test suite - [@michaelherold](https://github.com/michaelherold).
 * [#482](https://github.com/intridea/hashie/pull/482): Update Travis configs to make jruby builds run on trusty dist. - [@BobbyMcWho](https://github.com/BobbyMcWho).
-* Your contribution here.
 
 ## [3.6.0] - 2018-08-13
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ $ gem install hashie
 
 ## Upgrading
 
-You're reading the documentation for the next release of Hashie, which should be 3.6.1. Please read [UPGRADING](UPGRADING.md) when upgrading from a previous version. The current stable release is [3.6.0](https://github.com/intridea/hashie/blob/v3.6.0/README.md).
+## Stable Release
+
+You're reading the documentation for the stable release of Hashie, 3.7.0.
+
 
 ## Hash Extensions
 


### PR DESCRIPTION
The version.rb file was already bumped to 3.7.0 a while ago, I figure It makes sense to release this with the current minor-version appropriate changes that are currently merged to master.

Here's step 2 for release: https://github.com/BobbyMcWho/hashie/compare/release-3_7_0...BobbyMcWho:3_7_0-step-2