### PR TITLE
Allow forcing the disabling of Mash warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ scheme are considered to be bugs.
 * [#474](https://github.com/intridea/hashie/pull/474): Expose `YAML#safe_load` options in `Mash#load` - [@riouruma](https://github.com/riouruma), [@dblock](https://github.com/dblock).
 * [#478](https://github.com/intridea/hashie/pull/478): Added optional array parameter to `Hashie::Mash.disable_warnings` - [@bobbymcwho](https://github.com/bobbymcwho).
 * [#481](https://github.com/intridea/hashie/pull/481): Ruby 2.6 - Support Hash#merge and #merge! called with multiple Hashes/Mashes - [@bobbymcwho](https://github.com/bobbymcwho).
+* [#487](https://github.com/intridea/hashie/pull/487): Allow forcing the disabling of Mash warnings with `Hashie::Mash.disable_warnings force: true` - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -557,6 +557,12 @@ end
 Response.new(merge: 'true', compact: true, zip: '90210', zap: 'electric')
 ```
 
+If you really, truly need to globally disable this warning, you can force the disable using the following:
+
+```ruby
+Hashie::Mash.disable_warnings force: true
+```
+
 ### How does the wrapping of Mash sub-Hashes work?
 
 Mash duplicates any sub-Hashes that you add to it and wraps them in a Mash. This allows for infinite chaining of nested Hashes within a Mash without modifying the object(s) that are passed into the Mash. When you subclass Mash, the subclass wraps any sub-Hashes in its own class. This preserves any extensions that you mixed into the Mash subclass and allows them to work within the sub-Hashes, in addition to the main containing Mash.

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -78,8 +78,8 @@ module Hashie
     #
     # @api semipublic
     # @return [void]
-    def self.disable_warnings(*method_keys)
-      raise CannotDisableMashWarnings if self == Hashie::Mash
+    def self.disable_warnings(*method_keys, force: false)
+      raise CannotDisableMashWarnings if !force && self == Hashie::Mash
       if method_keys.any?
         disable_warnings_blacklist.concat(method_keys).tap(&:flatten!).uniq!
       else

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -159,8 +159,21 @@ describe Hashie::Mash do
       expect(logger_output).to be_blank
     end
 
-    it 'cannot disable logging on the base Mash' do
-      expect { Hashie::Mash.disable_warnings }.to raise_error(Hashie::Mash::CannotDisableMashWarnings)
+    context 'globally disabling logging on Mash' do
+      it 'cannot disable logging on the base Mash by default' do
+        expect { Hashie::Mash.disable_warnings }.to raise_error(Hashie::Mash::CannotDisableMashWarnings)
+      end
+
+      it 'can be forced off if you really, really want to' do
+        begin
+          expect { Hashie::Mash.disable_warnings(force: true) }.not_to raise_error
+          Hashie::Mash.new('trust' => { 'two' => 2 })
+          expect(logger_output).to be_empty
+        ensure
+          Hashie::Mash.instance_variable_get(:@_disable_warnings_blacklist).clear
+          Hashie::Mash.remove_instance_variable :@disable_warnings
+        end
+      end
     end
 
     it 'carries over the disable for warnings on grandchild classes' do


### PR DESCRIPTION
If someone really, truly wants to disable Mash warnings on the base
class, we should let them.

Closes #485