### PR TITLE
Change rubocop to restrict to 100 character lines.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,12 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Exclude:
     - 'Guardfile'
-  Max: 110
+  Max: 100
+
+Lint/UnifiedInteger:
+  Exclude:
+    - 'lib/hashie/extensions/coercion.rb'
+    - 'spec/hashie/extensions/coercion_spec.rb'
 
 Naming/FileName:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,12 +14,6 @@ Metrics/AbcSize:
 Metrics/CyclomaticComplexity:
   Max: 11
 
-# Offense count: 1
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 111
-
 # Offense count: 18
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
   # rubocop:disable Bundler/DuplicatedGem
   require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
-  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >= Hashie::Extensions::RubyVersion.new('2.4.0')
+  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+     Hashie::Extensions::RubyVersion.new('2.4.0')
     gem 'activesupport', '~> 5.x', require: false
   else
     gem 'activesupport', '~> 4.x', require: false

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -219,7 +219,8 @@ module Hashie
     end
 
     def fail_property_required_error!(property)
-      raise ArgumentError, "The property '#{property}' #{self.class.required_properties[property][:message]}"
+      raise ArgumentError,
+            "The property '#{property}' #{self.class.required_properties[property][:message]}"
     end
 
     def fail_no_property_error!(property)

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -21,8 +21,8 @@ module Hashie
           { Numeric => [Integer, Float, Complex, Rational] }
         else
           {
-            Integer => [Fixnum, Bignum], # rubocop:disable Lint/UnifiedInteger
-            Numeric => [Fixnum, Bignum, Float, Complex, Rational] # rubocop:disable Lint/UnifiedInteger
+            Integer => [Fixnum, Bignum],
+            Numeric => [Fixnum, Bignum, Float, Complex, Rational]
           }
         end
 
@@ -103,7 +103,8 @@ module Hashie
         #
         # @param [Class] from the type you would like coerced.
         # @param [Class] into the class into which you would like the value coerced.
-        # @option options [Boolean] :strict (true) whether use exact source class only or include ancestors
+        # @option options [Boolean] :strict (true) whether use exact source class
+        #   only or include ancestors
         #
         # @example Coerce all hashes into this special type of hash
         #   class SpecialHash < Hash

--- a/lib/hashie/extensions/dash/property_translation.rb
+++ b/lib/hashie/extensions/dash/property_translation.rb
@@ -137,7 +137,8 @@ module Hashie
           end
 
           def fail_self_transformation_error!(property_name)
-            raise ArgumentError, "Property name (#{property_name}) and :from option must not be the same"
+            raise ArgumentError,
+                  "Property name (#{property_name}) and :from option must not be the same"
           end
 
           def valid_transformer?(transformer)

--- a/lib/hashie/extensions/deep_fetch.rb
+++ b/lib/hashie/extensions/deep_fetch.rb
@@ -9,7 +9,8 @@ module Hashie
     #
     #  options.deep_fetch(:user, :non_existent_key) { 'a value' } #=> 'a value'
     #
-    # This is particularly useful for fetching values from deeply nested api responses or params hashes.
+    # This is particularly useful for fetching values from deeply nested api responses
+    #   or params hashes.
     module DeepFetch
       class UndefinedPathError < StandardError; end
 
@@ -20,7 +21,8 @@ module Hashie
             obj.fetch(arg)
           rescue ArgumentError, IndexError, NoMethodError => e
             break yield(arg) if block
-            raise UndefinedPathError, "Could not fetch path (#{args.join(' > ')}) at #{arg}", e.backtrace
+            raise UndefinedPathError,
+                  "Could not fetch path (#{args.join(' > ')}) at #{arg}", e.backtrace
           end
         end
       end

--- a/lib/hashie/extensions/deep_find.rb
+++ b/lib/hashie/extensions/deep_find.rb
@@ -1,3 +1,4 @@
+require 'hashie/extensions/deep_locate'
 module Hashie
   module Extensions
     module DeepFind
@@ -24,7 +25,12 @@ module Hashie
       # Performs a depth-first search on deeply nested data structures for
       # a key and returns all occurrences of the key.
       #
-      #  options = {users: [{location: {address: '123 Street'}}, {location: {address: '234 Street'}}]}
+      #  options = {
+      #    users: [
+      #      { location: {address: '123 Street'} },
+      #      { location: {address: '234 Street'}}
+      #    ]
+      #  }
       #  options.extend(Hashie::Extensions::DeepFind)
       #  options.deep_find_all(:address) # => ['123 Street', '234 Street']
       #
@@ -33,7 +39,10 @@ module Hashie
       #  end
       #
       #  my_hash = MyHash.new
-      #  my_hash[:users] = [{location: {address: '123 Street'}}, {location: {address: '234 Street'}}]
+      #  my_hash[:users] = [
+      #    {location: {address: '123 Street'}},
+      #    {location: {address: '234 Street'}}
+      #  ]
       #  my_hash.deep_find_all(:address) # => ['123 Street', '234 Street']
       def deep_find_all(key)
         matches = _deep_find_all(key)
@@ -49,7 +58,7 @@ module Hashie
       end
 
       def _deep_find_all(key, object = self, matches = [])
-        deep_locate_result = Hashie::Extensions::DeepLocate.deep_locate(key, object).tap do |result|
+        deep_locate_result = DeepLocate.deep_locate(key, object).tap do |result|
           result.map! { |element| element[key] }
         end
 

--- a/lib/hashie/extensions/mash/keep_original_keys.rb
+++ b/lib/hashie/extensions/mash/keep_original_keys.rb
@@ -15,7 +15,8 @@ module Hashie
       #   mash[:symbol_key] == mash['symbol_key']  #=> true
       module KeepOriginalKeys
         def self.included(descendant)
-          raise ArgumentError, "#{descendant} is not a kind of Hashie::Mash" unless descendant <= Hashie::Mash
+          error_message = "#{descendant} is not a kind of Hashie::Mash"
+          raise ArgumentError, error_message unless descendant <= Hashie::Mash
         end
 
         private

--- a/lib/hashie/extensions/method_access.rb
+++ b/lib/hashie/extensions/method_access.rb
@@ -73,7 +73,9 @@ module Hashie
       end
 
       def method_missing(name, *args)
-        return self[convert_key(Regexp.last_match[1])] = args.first if args.size == 1 && name.to_s =~ /(.*)=$/
+        if args.size == 1 && name.to_s =~ /(.*)=$/
+          return self[convert_key(Regexp.last_match[1])] = args.first
+        end
 
         super
       end
@@ -231,7 +233,8 @@ module Hashie
     # underscores.
     module MethodAccessWithOverride
       def self.included(base)
-        [MethodReader, MethodOverridingWriter, MethodQuery, MethodOverridingInitializer].each do |mod|
+        [MethodReader, MethodOverridingWriter,
+         MethodQuery, MethodOverridingInitializer].each do |mod|
           base.send :include, mod
         end
       end

--- a/lib/hashie/extensions/strict_key_access.rb
+++ b/lib/hashie/extensions/strict_key_access.rb
@@ -1,6 +1,7 @@
 module Hashie
   module Extensions
-    # SRP: This extension will fail an error whenever a key is accessed that does not exist in the hash.
+    # SRP: This extension will fail an error whenever a key is accessed
+    #   that does not exist in the hash.
     #
     #   EXAMPLE:
     #
@@ -21,8 +22,8 @@ module Hashie
     module StrictKeyAccess
       class DefaultError < StandardError
         def initialize
-          super(
-            'Setting or using a default with Hashie::Extensions::StrictKeyAccess does not make sense'
+          super('Setting or using a default with Hashie::Extensions::StrictKeyAccess'\
+                ' does not make sense'
           )
         end
       end

--- a/lib/hashie/rash.rb
+++ b/lib/hashie/rash.rb
@@ -117,7 +117,7 @@ module Hashie
         end
 
       when Regexp
-        # Reverse operation: `rash[/regexp/]` returns all the hash's string keys which match the regexp
+        # Reverse operation: `rash[/regexp/]` returns all string keys matching the regexp
         @hash.each do |key, val|
           yield val if key.is_a?(String) && query =~ key
         end

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -265,11 +265,13 @@ describe DashTest do
     end
 
     it 'fails with non-existent properties' do
-      expect { subject.merge(middle_name: 'James') }.to raise_error(*no_property_error('middle_name'))
+      expect { subject.merge(middle_name: 'James') }
+        .to raise_error(*no_property_error('middle_name'))
     end
 
     it 'errors out when attempting to set a required property to nil' do
-      expect { subject.merge(first_name: nil) }.to raise_error(*property_required_error('first_name'))
+      expect { subject.merge(first_name: nil) }
+        .to raise_error(*property_required_error('first_name'))
     end
 
     context 'given a block' do
@@ -368,8 +370,12 @@ describe DashTest do
     let(:params) { { first_name: 'Alice', email: 'alice@example.com' } }
 
     context 'when there is coercion' do
-      let(:params_before) { { city: 'nyc', person: { first_name: 'Bob', email: 'bob@example.com' } } }
-      let(:params_after) { { city: 'sfo', person: { first_name: 'Alice', email: 'alice@example.com' } } }
+      let(:params_before) do
+        { city: 'nyc', person: { first_name: 'Bob', email: 'bob@example.com' } }
+      end
+      let(:params_after) do
+        { city: 'sfo', person: { first_name: 'Alice', email: 'alice@example.com' } }
+      end
 
       subject { DashWithCoercion.new(params_before) }
 
@@ -516,7 +522,8 @@ describe ConditionallyRequiredTest do
   end
 
   it 'allows a conditionally required property to be set if required' do
-    expect { ConditionallyRequiredTest.new(username: 'bob.smith', password: '$ecure!') }.not_to raise_error
+    expect { ConditionallyRequiredTest.new(username: 'bob.smith', password: '$ecure!') }
+      .not_to raise_error
   end
 end
 

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -459,8 +459,12 @@ describe Hashie::Extensions::Coercion do
           coerce_key :categories, Array[CategoryHash]
         end
 
-        let(:category) { CategoryHash.new(type: 'rubygem', products: [Hashie::Mash.new(name: 'Hashie')]) }
-        let(:product) { ProductHash.new(name: 'Hashie', categories: [Hashie::Mash.new(type: 'rubygem')]) }
+        let(:category) do
+          CategoryHash.new(type: 'rubygem', products: [Hashie::Mash.new(name: 'Hashie')])
+        end
+        let(:product) do
+          ProductHash.new(name: 'Hashie', categories: [Hashie::Mash.new(type: 'rubygem')])
+        end
 
         it 'coerces CategoryHash[:products] correctly' do
           expected = [ProductHash]
@@ -560,23 +564,26 @@ describe Hashie::Extensions::Coercion do
 
       it 'raises a CoercionError when coercion is not possible' do
         type =
-          if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >= Hashie::Extensions::RubyVersion.new('2.4.0')
+          if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+             Hashie::Extensions::RubyVersion.new('2.4.0')
             Integer
           else
-            Fixnum # rubocop:disable Lint/UnifiedInteger
+            Fixnum
           end
 
         subject.coerce_value type, Symbol
-        expect { instance[:hi] = 1 }
-          .to raise_error(Hashie::CoercionError, /Cannot coerce property :hi from #{type} to Symbol/)
+        expect { instance[:hi] = 1 }.to raise_error(
+          Hashie::CoercionError, /Cannot coerce property :hi from #{type} to Symbol/
+        )
       end
 
       it 'coerces Integer to String' do
         type =
-          if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >= Hashie::Extensions::RubyVersion.new('2.4.0')
+          if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+             Hashie::Extensions::RubyVersion.new('2.4.0')
             Integer
           else
-            Fixnum # rubocop:disable Lint/UnifiedInteger
+            Fixnum
           end
 
         subject.coerce_value type, String

--- a/spec/hashie/extensions/deep_find_spec.rb
+++ b/spec/hashie/extensions/deep_find_spec.rb
@@ -36,7 +36,8 @@ describe Hashie::Extensions::DeepFind do
 
   describe '#deep_find_all' do
     it 'detects all values from a nested hash' do
-      expect(instance.deep_find_all(:title)).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+      expect(instance.deep_find_all(:title))
+        .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
     end
 
     it 'returns nil if it does not find any matches' do
@@ -92,8 +93,10 @@ describe Hashie::Extensions::DeepFind do
 
     describe '#deep_find_all' do
       it 'indifferently detects all values from a nested hash' do
-        expect(instance.deep_find_all(:title)).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
-        expect(instance.deep_find_all('title')).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+        expect(instance.deep_find_all(:title))
+          .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+        expect(instance.deep_find_all('title'))
+          .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
       end
 
       it 'indifferently returns nil if it does not find any matches' do
@@ -126,8 +129,10 @@ describe Hashie::Extensions::DeepFind do
 
     describe '#deep_find_all' do
       it 'indifferently detects all values from a nested hash' do
-        expect(instance.deep_find_all(:title)).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
-        expect(instance.deep_find_all('title')).to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+        expect(instance.deep_find_all(:title))
+          .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+        expect(instance.deep_find_all('title'))
+          .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
       end
 
       it 'indifferently returns nil if it does not find any matches' do

--- a/spec/hashie/extensions/deep_locate_spec.rb
+++ b/spec/hashie/extensions/deep_locate_spec.rb
@@ -56,7 +56,8 @@ describe Hashie::Extensions::DeepLocate do
   describe '.deep_locate' do
     context 'if called with a non-callable comparator' do
       it 'creates a key comparator on-th-fly' do
-        expect(described_class.deep_locate(:lsr10, hash)).to eq([hash[:query][:bool][:must_not][0][:range]])
+        expect(described_class.deep_locate(:lsr10, hash))
+          .to eq([hash[:query][:bool][:must_not][0][:range]])
       end
     end
 

--- a/spec/hashie/extensions/deep_merge_spec.rb
+++ b/spec/hashie/extensions/deep_merge_spec.rb
@@ -13,7 +13,9 @@ describe Hashie::Extensions::DeepMerge do
   end
 
   context 'without &block' do
-    let(:h1) { subject.new.merge(a: 'a', a1: 42, b: 'b', c: { c1: 'c1', c2: { a: 'b' }, c3: { d1: 'd1' } }) }
+    let(:h1) do
+      subject.new.merge(a: 'a', a1: 42, b: 'b', c: { c1: 'c1', c2: { a: 'b' }, c3: { d1: 'd1' } })
+    end
     let(:h2) { { a: 1, a1: 1, c: { c1: 2, c2: 'c2', c3: { d2: 'd2' } }, e: { e1: 1 } } }
     let(:expected_hash) do
       { a: 1, a1: 1, b: 'b', c: { c1: 2, c2: 'c2', c3: { d1: 'd1', d2: 'd2' } }, e: { e1: 1 } }

--- a/spec/hashie/hash_spec.rb
+++ b/spec/hashie/hash_spec.rb
@@ -64,7 +64,12 @@ describe Hash do
     end
 
     it '#to_hash returns a hash with same keys' do
-      hash = Hashie::Hash['a' => 'hey', 123 => 'bob', 'array' => [1, 2, 3], subhash: ClassRespondsToHash.new]
+      hash = Hashie::Hash[
+        'a' => 'hey',
+        123 => 'bob',
+        'array' => [1, 2, 3],
+        subhash: ClassRespondsToHash.new
+      ]
       stringified_hash = hash.to_hash
 
       expected = {
@@ -78,7 +83,12 @@ describe Hash do
     end
 
     it '#to_hash with stringify_keys set to true returns a hash with stringified_keys' do
-      hash = Hashie::Hash['a' => 'hey', 123 => 'bob', 'array' => [1, 2, 3], subhash: ClassRespondsToHash.new]
+      hash = Hashie::Hash[
+        'a' => 'hey',
+        123 => 'bob',
+        'array' => [1, 2, 3],
+        subhash: ClassRespondsToHash.new
+      ]
       symbolized_hash = hash.to_hash(stringify_keys: true)
 
       expected = {
@@ -92,7 +102,12 @@ describe Hash do
     end
 
     it '#to_hash with symbolize_keys set to true returns a hash with symbolized keys' do
-      hash = Hashie::Hash['a' => 'hey', 123 => 'bob', 'array' => [1, 2, 3], subhash: ClassRespondsToHash.new]
+      hash = Hashie::Hash[
+        'a' => 'hey',
+        123 => 'bob',
+        'array' => [1, 2, 3],
+        subhash: ClassRespondsToHash.new
+      ]
       symbolized_hash = hash.to_hash(symbolize_keys: true)
 
       expected = {

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -302,14 +302,16 @@ describe Hashie::Mash do
 
       # http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-update
       it 'accepts a block' do
-        duped = subject.merge(details: { address: 'Pasadena CA' }) { |_, oldv, newv| [oldv, newv].join(', ') }
+        duped = subject.merge(details: { address: 'Pasadena CA' }) do |_, oldv, newv|
+          [oldv, newv].join(', ')
+        end
+
         expect(duped.details.address).to eq 'Nowhere road, Pasadena CA'
       end
 
       it 'copies values for non-duplicate keys when a block is supplied' do
-        duped =
-          subject
-          .merge(details: { address: 'Pasadena CA', state: 'West Thoughtleby' }) { |_, oldv, _| oldv }
+        m_hash = { details: { address: 'Pasadena CA', state: 'West Thoughtleby' } }
+        duped = subject.merge(m_hash) { |_, oldv, _| oldv }
 
         expect(duped.details.address).to eq 'Nowhere road'
         expect(duped.details.state).to eq 'West Thoughtleby'

--- a/spec/hashie/trash_spec.rb
+++ b/spec/hashie/trash_spec.rb
@@ -188,7 +188,9 @@ describe Hashie::Trash do
     end
 
     it 'transforms the value when given in constructor' do
-      expect(TrashLambdaTestWithProperties.new(first_name: 'Michael').first_name).to eq 'Michael'.reverse
+      expect(
+        TrashLambdaTestWithProperties.new(first_name: 'Michael').first_name
+      ).to eq 'Michael'.reverse
     end
 
     context 'when :from option is given' do
@@ -297,7 +299,9 @@ describe Hashie::Trash do
         property :copy_of_id, from: :id, required: true, message: 'must be set'
       end
 
-      expect { with_required.new }.to raise_error(ArgumentError, "The property 'copy_of_id' must be set")
+      expect { with_required.new }.to raise_error(
+        ArgumentError, "The property 'copy_of_id' must be set"
+      )
     end
 
     it 'does not set properties that do not exist' do
@@ -308,7 +312,9 @@ describe Hashie::Trash do
       subject = from_non_property.new(value: 0)
 
       expect(subject).not_to respond_to(:value)
-      expect { subject[:value] }.to raise_error(NoMethodError, "The property 'value' is not defined for .")
+      expect { subject[:value] }.to raise_error(
+        NoMethodError, "The property 'value' is not defined for ."
+      )
       expect(subject.to_h[:value]).to eq(nil)
       expect(subject.copy_of_value).to eq(0)
     end

--- a/spec/integration/elasticsearch/integration_spec.rb
+++ b/spec/integration/elasticsearch/integration_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'elaasticsearch-model' do
 
   def stub_elasticsearch_client
     response = double('Response', body: '{}')
-    allow_any_instance_of(Elasticsearch::Transport::Client).to receive(:perform_request) { response }
+    allow_any_instance_of(Elasticsearch::Transport::Client).to\
+      receive(:perform_request) { response }
   end
 end

--- a/spec/integration/rails/integration_spec.rb
+++ b/spec/integration/rails/integration_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe 'rails', type: :request do
     $stdout = original_stdout
   end
 
-  it 'does not log anything to STDOUT when initializing and sets the Hashie logger to the Rails logger' do
+  it 'does not log anything to STDOUT when initializing' do
     expect(stdout.string).to eq('')
+  end
+
+  it 'sets the Hashie logger to the Rails logger' do
     expect(Hashie.logger).to eq(Rails.logger)
   end
 


### PR DESCRIPTION
For accessibility reasons, we should limit our lines to 100 chars max.
https://github.com/slack-ruby/slack-ruby-client/pull/293#discussion_r309472083

We could go more aggressive on this, but not sure if we should. 