### PR TITLE
Remove references to blacklists and whitelists

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ class Response < Hashie::Mash
 end
 ```
 
-Disable warnings will honor the last `disable_warnings` call. Calling without parameters will override the blacklist, and calling with parameters will create a new blacklist. This includes child classes that inherit from a class that disables warnings.
+Disable warnings will honor the last `disable_warnings` call. Calling without parameters will override the ignored methods list, and calling with parameters will create a new ignored methods list. This includes child classes that inherit from a class that disables warnings.
 
 ```ruby
 class Message < Hashie::Mash
@@ -633,10 +633,10 @@ mash[1] #=> { name: 'John', lastname: 'Doe' }
 
 The `Mash#load` method calls `YAML.safe_load(path, [], [], true)`.
 
-Specify `whitelist_symbols`, `whitelist_classes` and `aliases` options as needed.
+Specify `permitted_symbols`, `permitted_classes` and `aliases` options as needed.
 
 ```ruby
-Mash.load('data/user.csv', whitelist_classes: [Symbol], whitelist_symbols: [], aliases: false)
+Mash.load('data/user.csv', permitted_classes: [Symbol], permitted_symbols: [], aliases: false)
 ```
 
 ### Mash Extension: KeepOriginalKeys

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -50,7 +50,7 @@ There shouldn't really be a case that anyone was relying on catching this specif
 
 The `Hashie::Mash#load` method now accepts options, changing the interface of `Parser#initialize`. If you have a custom parser, you must update its `initialize` method.
 
-For example, `Hashie::Extensions::Parsers::YamlErbParser` now accepts `whitelist_classes`, `whitelist_symbols` and `aliases` options.
+For example, `Hashie::Extensions::Parsers::YamlErbParser` now accepts `permitted_classes`, `permitted_symbols` and `aliases` options.
 
 Before:
 
@@ -76,7 +76,7 @@ end
 Options can now be passed into `Mash#load`.
 
 ```ruby
-Mash.load(filename, whitelist_classes: [])
+Mash.load(filename, permitted_classes: [])
 ```
 
 ### Upgrading to 3.5.2

--- a/lib/hashie/extensions/key_conflict_warning.rb
+++ b/lib/hashie/extensions/key_conflict_warning.rb
@@ -34,7 +34,7 @@ module Hashie
         @disable_warnings ||= false
       end
 
-      # Returns an array of blacklisted methods that this class disables warnings for.
+      # Returns an array of methods that this class disables warnings for.
       #
       # @api semipublic
       # @return [Boolean]

--- a/lib/hashie/extensions/parsers/yaml_erb_parser.rb
+++ b/lib/hashie/extensions/parsers/yaml_erb_parser.rb
@@ -15,10 +15,11 @@ module Hashie
         def perform
           template = ERB.new(@content)
           template.filename = @file_path
-          whitelist_classes = @options.fetch(:whitelist_classes) { [] }
-          whitelist_symbols = @options.fetch(:whitelist_symbols) { [] }
+          permitted_classes = @options.fetch(:permitted_classes) { [] }
+          permitted_symbols = @options.fetch(:permitted_symbols) { [] }
           aliases = @options.fetch(:aliases) { true }
-          YAML.safe_load template.result, whitelist_classes, whitelist_symbols, aliases
+          # TODO: Psych in newer rubies expects these args to be keyword args.
+          YAML.safe_load template.result, permitted_classes, permitted_symbols, aliases
         end
 
         def self.perform(file_path, options = {})

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -103,7 +103,7 @@ module Hashie
 
     # Creates a new anonymous subclass with key conflict
     # warnings disabled. You may pass an array of method
-    # symbols to restrict the warnings blacklist to.
+    # symbols to restrict the disabled warnings to.
     # Hashie::Mash.quiet.new(hash) all warnings disabled.
     # Hashie::Mash.quiet(:zip).new(hash) only zip warning
     # is disabled.

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -176,7 +176,7 @@ describe Hashie::Mash do
       expect(logger_output).to be_blank
     end
 
-    it 'writes to logger when a key is overridden that is not blacklisted' do
+    it 'writes to logger when a key is overridden that is not ignored' do
       mash_class = Class.new(Hashie::Mash) do
         disable_warnings :merge
       end
@@ -185,7 +185,7 @@ describe Hashie::Mash do
       expect(logger_output).not_to be_blank
     end
 
-    it 'does not write to logger when a key is overridden that is blacklisted' do
+    it 'does not write to logger when a key is overridden that is ignored' do
       mash_class = Class.new(Hashie::Mash) do
         disable_warnings :zip
       end
@@ -194,7 +194,7 @@ describe Hashie::Mash do
       expect(logger_output).to be_blank
     end
 
-    it 'carries over the disabled blacklist for warnings on grandchild classes' do
+    it 'carries over the ignored warnings list for warnings on grandchild classes' do
       child_class = Class.new(Hashie::Mash) do
         disable_warnings :zip, :merge
       end
@@ -208,7 +208,7 @@ describe Hashie::Mash do
 
     context 'multiple disable_warnings calls' do
       context 'calling disable_warnings multiple times with parameters' do
-        it 'appends each new parameter to the blacklist' do
+        it 'appends each new parameter to the ignore list' do
           child_class = Class.new(Hashie::Mash) do
             disable_warnings :zip
             disable_warnings :merge
@@ -220,7 +220,7 @@ describe Hashie::Mash do
       end
 
       context 'calling disable_warnings without keys after calling with keys' do
-        it 'uses the last call to ignore the blacklist' do
+        it 'uses the last call to determine the ignore list' do
           child_class = Class.new(Hashie::Mash) do
             disable_warnings :zip
             disable_warnings
@@ -234,7 +234,7 @@ describe Hashie::Mash do
       end
 
       context 'calling disable_parameters with keys after calling without keys' do
-        it 'only ignores logging for the blacklisted methods' do
+        it 'only ignores logging for ignored methods' do
           child_class = Class.new(Hashie::Mash) do
             disable_warnings
             disable_warnings :zip
@@ -793,30 +793,30 @@ describe Hashie::Mash do
     end
 
     context 'when the file has symbols' do
-      it 'can override the value of whitelist_classes' do
-        mash = Hashie::Mash.load('spec/fixtures/yaml_with_symbols.yml', whitelist_classes: [Symbol])
+      it 'can override the value of permitted_classes' do
+        mash = Hashie::Mash.load('spec/fixtures/yaml_with_symbols.yml', permitted_classes: [Symbol])
         expect(mash.user_icon.width).to eq(200)
       end
-      it 'uses defaults for whitelist_classes' do
+      it 'uses defaults for permitted_classes' do
         expect do
           Hashie::Mash.load('spec/fixtures/yaml_with_symbols.yml')
         end.to raise_error Psych::DisallowedClass, /Symbol/
       end
-      it 'can override the value of whitelist_symbols' do
+      it 'can override the value of permitted_symbols' do
         mash = Hashie::Mash.load('spec/fixtures/yaml_with_symbols.yml',
-                                 whitelist_classes: [Symbol],
-                                 whitelist_symbols: %i[
+                                 permitted_classes: [Symbol],
+                                 permitted_symbols: %i[
                                    user_icon
                                    width
                                    height
                                  ])
         expect(mash.user_icon.width).to eq(200)
       end
-      it 'raises an error on insufficient whitelist_symbols' do
+      it 'raises an error on insufficient permitted_symbols' do
         expect do
           Hashie::Mash.load('spec/fixtures/yaml_with_symbols.yml',
-                            whitelist_classes: [Symbol],
-                            whitelist_symbols: %i[
+                            permitted_classes: [Symbol],
+                            permitted_symbols: %i[
                               user_icon
                               width
                             ])


### PR DESCRIPTION
Self explanatory, the whitelist changes in particular match what Ruby 2.6+ refer to them as.
It looks like Ruby 2.6 wants those params passed in as keyword args, but that's a task for another PR. 