### PR TITLE
Fix Trash subclasses changing superclass transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Fixed
 
-* Your contribution here.
+* [#593](https://github.com/hashie/hashie/pull/593): Fix trash subclasses changing superclass transformers - [@complex857](https://github.com/complex857).
 
 ### Security
 

--- a/lib/hashie/extensions/dash/property_translation.rb
+++ b/lib/hashie/extensions/dash/property_translation.rb
@@ -43,6 +43,7 @@ module Hashie
           base.instance_variable_set(:@translations_hash, ::Hash.new { |hash, key| hash[key] = {} })
           base.extend(ClassMethods)
           base.send(:include, InstanceMethods)
+          base.extend Hashie::Extensions::DeepMerge
         end
 
         module ClassMethods
@@ -54,7 +55,7 @@ module Hashie
           def inherited(klass)
             super
             klass.instance_variable_set(:@transforms, transforms.dup)
-            klass.instance_variable_set(:@translations_hash, translations_hash.dup)
+            klass.instance_variable_set(:@translations_hash, _deep_dup(translations_hash))
           end
 
           def permitted_input_keys

--- a/spec/hashie/trash_spec.rb
+++ b/spec/hashie/trash_spec.rb
@@ -261,6 +261,17 @@ describe Hashie::Trash do
     it 'inherit properties translations' do
       expect(TranslationB.new('someValue' => '123').some_value).to eq(123)
     end
+
+    context 'subclass overwrites translation' do
+      class TranslationC < TranslationA
+        property :some_value, from: 'someValue', with: ->(v) { v.to_s.reverse }
+      end
+
+      it 'subclass get to change translation without affecting baseclass' do
+        expect(TranslationA.new('someValue' => '123').some_value).to eq(123)
+        expect(TranslationC.new('someValue' => '123').some_value).to eq('321')
+      end
+    end
   end
 
   it 'raises an error when :from have the same value as property' do


### PR DESCRIPTION
When a Trash gets subclassed and the subclass re-defines the same property with a different transformer, the superclass's transformer gets replaced because how `::Hash.dup` works in ruby

To keep these isolated we need to deep_dup the translations_hash in inherited hook